### PR TITLE
Port over missing bindings from my deprecated repo

### DIFF
--- a/__tests__/fixtures/testPage.css
+++ b/__tests__/fixtures/testPage.css
@@ -1,0 +1,6 @@
+/* This is "testPage.css" */
+html {
+  color: #222;
+  font-size: 1em;
+  line-height: 1.4;
+}

--- a/__tests__/fixtures/testPage.js
+++ b/__tests__/fixtures/testPage.js
@@ -1,0 +1,2 @@
+// This is "testPage.js"
+console.log('nothing here');

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -384,6 +384,19 @@ describe("Page", () => {
          )
     )
   );
+  testPromise("evaluateHandle()", () =>
+    Js.Promise.(
+      {
+        let eval = [%raw
+          {| function () { return Promise.resolve(document); } |}
+        ];
+        page^ |> Page.evaluateHandle(eval, [||]);
+      }
+      |> then_(jsHandler =>
+           jsHandler |> expect |> ExpectJs.toBeTruthy |> Js.Promise.resolve
+         )
+    )
+  );
   afterAllPromise(() =>
     Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -138,7 +138,7 @@ describe("Page", () => {
       page^
       |> Page.selectAllEval("html,body", getLengthOfElementsJs)
       |> then_(serializable =>
-           serializable |> expect |> toBe(2) |> Js.Promise.resolve
+           serializable |> expect |> toBe(2) |> resolve
          )
     )
   );
@@ -149,7 +149,7 @@ describe("Page", () => {
       |> then_(serializable =>
            expect(serializable)
            |> toBe("<html><head></head><body></body></html>")
-           |> Js.Promise.resolve
+           |> resolve
          )
     )
   );
@@ -278,7 +278,7 @@ describe("Page", () => {
       |> Page.authenticate(
            Js.Null.return({"username": "foo", "password": "bar"})
          )
-      |> then_(() => pass |> Js.Promise.resolve)
+      |> then_(() => pass |> resolve)
     )
   );
   testPromise("cookies()", () =>
@@ -333,6 +333,36 @@ describe("Page", () => {
       |> then_(() => page^ |> Page.deleteCookie([||]))
       |> then_(() => page^ |> Page.cookies([||]))
       |> then_(cookies => cookies |> expect |> toHaveLength(0) |> resolve)
+    )
+  );
+  testPromise("emulate()", () =>
+    Js.Promise.(
+      page^
+      |> Page.emulate({
+           "viewport": {
+             "width": 320,
+             "height": 480,
+             "deviceScaleFactor": 2,
+             "isMobile": Js.true_,
+             "hasTouch": Js.true_,
+             "isLandscape": Js.true_
+           },
+           "userAgent": ""
+         })
+      |> then_(() =>
+           page^
+           |> Page.viewport()
+           |> expect
+           |> ExpectJs.toMatchObject({
+                "width": 320,
+                "height": 480,
+                "deviceScaleFactor": 2,
+                "isMobile": Js.true_,
+                "hasTouch": Js.true_,
+                "isLandscape": Js.true_
+              })
+           |> resolve
+         )
     )
   );
   afterAllPromise(() =>

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -237,7 +237,7 @@ describe("Page", () => {
       Browser.newPage(browser^)
       |> then_(page =>
            page
-           |> Page.addScriptTag(~path=testPageJsPath)
+           |> Page.addScriptTag(Page.makeTagOptions(~path=testPageJsPath, ()))
            |> then_(_elementHandle => Page.content(page))
            |> then_(content =>
                 Page.close(page)
@@ -256,7 +256,7 @@ describe("Page", () => {
       Browser.newPage(browser^)
       |> then_(page =>
            page
-           |> Page.addStyleTag(~path=testPageCssPath)
+           |> Page.addStyleTag(Page.makeTagOptions(~path=testPageCssPath, ()))
            |> then_(_elementHandle => Page.content(page))
            |> then_(content =>
                 Page.close(page)

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -91,7 +91,7 @@ describe("Page", () => {
       Puppeteer.launch(~options=noSandbox, ())
       |> then_(res => {
            browser := res;
-           Browser.newPage(browser^);
+           browser^ |> Browser.newPage;
          })
       |> then_(res => {
            page := res;
@@ -158,7 +158,8 @@ describe("Page", () => {
   );
   testPromise("goto()", () =>
     Js.Promise.(
-      Browser.newPage(browser^)
+      browser^
+      |> Browser.newPage
       |> then_(page => {
            let options = Navigation.makeOptions(~timeout=25000., ());
            page |> Page.goto("https://google.com", ~options, ());
@@ -216,7 +217,8 @@ describe("Page", () => {
   );
   testPromise("type()", () =>
     Js.Promise.(
-      Browser.newPage(browser^)
+      browser^
+      |> Browser.newPage
       |> then_(page =>
            all2((resolve(page), page |> Page.setContent(testPageContent)))
          )
@@ -234,7 +236,8 @@ describe("Page", () => {
   );
   testPromise("addScriptTag()", () =>
     Js.Promise.(
-      Browser.newPage(browser^)
+      browser^
+      |> Browser.newPage
       |> then_(page =>
            page
            |> Page.addScriptTag(Page.makeTagOptions(~path=testPageJsPath, ()))
@@ -253,7 +256,8 @@ describe("Page", () => {
   );
   testPromise("addStyleTag()", () =>
     Js.Promise.(
-      Browser.newPage(browser^)
+      browser^
+      |> Browser.newPage
       |> then_(page =>
            page
            |> Page.addStyleTag(Page.makeTagOptions(~path=testPageCssPath, ()))

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -281,6 +281,60 @@ describe("Page", () => {
       |> then_(() => pass |> Js.Promise.resolve)
     )
   );
+  testPromise("cookies()", () =>
+    Js.Promise.(
+      page^
+      |> Page.setCookie([|
+           Page.makeCookie(
+             ~name="foo",
+             ~value="bar",
+             ~url="http://localhost",
+             ()
+           )
+         |])
+      |> then_(() => page^ |> Page.cookies([|"http://localhost"|]))
+      |> then_(cookies => cookies |> expect |> toHaveLength(1) |> resolve)
+    )
+  );
+  testPromise("setCookie()", () =>
+    Js.Promise.(
+      page^
+      |> Page.setCookie([|
+           Page.makeCookie(
+             ~name="foo",
+             ~value="bar",
+             ~url="http://localhost",
+             ()
+           ),
+           Page.makeCookie(
+             ~name="foo2",
+             ~value="bar2",
+             ~url="http://localhost2",
+             ()
+           )
+         |])
+      |> then_(() =>
+           page^ |> Page.cookies([|"http://localhost", "http://localhost2"|])
+         )
+      |> then_(cookies => cookies |> expect |> toHaveLength(2) |> resolve)
+    )
+  );
+  testPromise("deleteCookie()", () =>
+    Js.Promise.(
+      page^
+      |> Page.setCookie([|
+           Page.makeCookie(
+             ~name="foo",
+             ~value="bar",
+             ~url="http://localhost",
+             ()
+           )
+         |])
+      |> then_(() => page^ |> Page.deleteCookie([||]))
+      |> then_(() => page^ |> Page.cookies([||]))
+      |> then_(cookies => cookies |> expect |> toHaveLength(0) |> resolve)
+    )
+  );
   afterAllPromise(() =>
     Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -41,7 +41,7 @@ describe("Puppeteer", () => {
     Puppeteer.executablePath() |> expect |> toContainString("chromium")
   );
   test("defaultArgs()", () =>
-    Puppeteer.defaultArgs() |> expect |> toHaveLength(17)
+    Puppeteer.defaultArgs() |> Array.length |> expect |> toBeGreaterThan(0)
   );
 });
 
@@ -137,9 +137,7 @@ describe("Page", () => {
     Js.Promise.(
       page^
       |> Page.selectAllEval("html,body", getLengthOfElementsJs)
-      |> then_(serializable =>
-           serializable |> expect |> toBe(2) |> resolve
-         )
+      |> then_(serializable => serializable |> expect |> toBe(2) |> resolve)
     )
   );
   testPromise("$eval()", () =>

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -8,6 +8,10 @@ let getElementValueJs = [%raw
   {| function (element) { return element.value; } |}
 ];
 
+let getLengthOfElementsJs = [%raw
+  {| function (elements) { return elements.length; } |}
+];
+
 let testPagePath =
   Node.Path.resolve(
     [%bs.node __dirname] |> Js.Option.getWithDefault(""),
@@ -116,6 +120,15 @@ describe("Page", () => {
       Page.selectXPath(page^, ~xpath="/html/body")
       |> then_(elementHandles =>
            expect(elementHandles) |> ExpectJs.toHaveLength(1) |> resolve
+         )
+    )
+  );
+  testPromise("$$eval()", () =>
+    Js.Promise.(
+      page^
+      |> Page.selectAllEval("html,body", getLengthOfElementsJs)
+      |> then_(serializable =>
+           serializable |> expect |> toBe(2) |> Js.Promise.resolve
          )
     )
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -272,6 +272,15 @@ describe("Page", () => {
          )
     )
   );
+  testPromise("authenticate()", () =>
+    Js.Promise.(
+      page^
+      |> Page.authenticate(
+           Js.Null.return({"username": "foo", "password": "bar"})
+         )
+      |> then_(() => pass |> Js.Promise.resolve)
+    )
+  );
   afterAllPromise(() =>
     Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -12,6 +12,10 @@ let getLengthOfElementsJs = [%raw
   {| function (elements) { return elements.length; } |}
 ];
 
+let getElementOuterHTMLJs = [%raw
+  {| function (element) { return element.outerHTML; } |}
+];
+
 let testPagePath =
   Node.Path.resolve(
     [%bs.node __dirname] |> Js.Option.getWithDefault(""),
@@ -129,6 +133,17 @@ describe("Page", () => {
       |> Page.selectAllEval("html,body", getLengthOfElementsJs)
       |> then_(serializable =>
            serializable |> expect |> toBe(2) |> Js.Promise.resolve
+         )
+    )
+  );
+  testPromise("$eval()", () =>
+    Js.Promise.(
+      page^
+      |> Page.selectOneEval("html", getElementOuterHTMLJs)
+      |> then_(serializable =>
+           expect(serializable)
+           |> toBe("<html><head></head><body></body></html>")
+           |> Js.Promise.resolve
          )
     )
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -363,6 +363,11 @@ describe("Page", () => {
          )
     )
   );
+  testPromise("emulateMedia()", () =>
+    Js.Promise.(
+      page^ |> Page.emulateMedia(Some(Print)) |> then_(() => pass |> resolve)
+    )
+  );
   afterAllPromise(() =>
     Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -26,6 +26,8 @@ let testPagePath = Node.Path.resolve(fixturesPath, "./testPage.html");
 
 let testPageJsPath = Node.Path.resolve(fixturesPath, "./testPage.js");
 
+let testPageCssPath = Node.Path.resolve(fixturesPath, "./testPage.css");
+
 let testPageContent = Node.Fs.readFileAsUtf8Sync(testPagePath);
 
 let noSandbox =
@@ -245,6 +247,25 @@ describe("Page", () => {
                      content
                      |> expect
                      |> toContainString("// This is \"testPage.js\"")
+                     |> resolve
+                   )
+              )
+         )
+    )
+  );
+  testPromise("addStyleTag()", () =>
+    Js.Promise.(
+      Browser.newPage(browser^)
+      |> then_(page =>
+           page
+           |> Page.addStyleTag(~path=testPageCssPath)
+           |> then_(_elementHandle => Page.content(page))
+           |> then_(content =>
+                Page.close(page)
+                |> then_(() =>
+                     content
+                     |> expect
+                     |> toContainString("/* This is \"testPage.css\" */")
                      |> resolve
                    )
               )

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -368,6 +368,22 @@ describe("Page", () => {
       page^ |> Page.emulateMedia(Some(Print)) |> then_(() => pass |> resolve)
     )
   );
+  testPromise("evaluate()", () =>
+    Js.Promise.(
+      {
+        let eval = [%raw {| function () { return Promise.resolve("ok"); } |}];
+        page^ |> Page.evaluate(eval, [||]);
+      }
+      |> then_(serializable =>
+           serializable
+           |> Js.Json.decodeString
+           |> Js.Option.getWithDefault("")
+           |> expect
+           |> toBe("ok")
+           |> resolve
+         )
+    )
+  );
   afterAllPromise(() =>
     Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
   );

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -22,11 +22,14 @@ let noSandbox =
     ()
   );
 
-describe("Puppeteer", () =>
+describe("Puppeteer", () => {
   test("executablePath", () =>
     Puppeteer.executablePath() |> expect |> toContainString("chromium")
-  )
-);
+  );
+  test("defaultArgs()", () =>
+    Puppeteer.defaultArgs() |> expect |> toHaveLength(17)
+  );
+});
 
 describe("Browser", () => {
   let browser = ref(Browser.empty());

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -369,7 +369,12 @@ describe("Page", () => {
   );
   testPromise("emulateMedia()", () =>
     Js.Promise.(
-      page^ |> Page.emulateMedia(Some(Print)) |> then_(() => pass |> resolve)
+      page^ |> Page.emulateMedia(`print) |> then_(() => pass |> resolve)
+    )
+  );
+  testPromise("emulateMediaDisable()", () =>
+    Js.Promise.(
+      page^ |> Page.emulateMediaDisable |> then_(() => pass |> resolve)
     )
   );
   testPromise("evaluate()", () =>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/__tests__/fixtures'],
+};

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -48,6 +48,12 @@ external waitForXPath :
   Js.Promise.t(ElementHandle.t) =
   "";
 
+/* TODP: Add support [, ...args] */
 [@bs.send.pipe : t]
 external selectOneEval : (string, unit => unit) => Js.Promise.t('a) =
   "$eval";
+
+/* TODP: Add support [, ...args] */
+[@bs.send.pipe : t]
+external selectAllEval : (string, unit => unit) => Js.Promise.t('a) =
+  "$$eval";

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -70,29 +70,12 @@ external selectOneEval : (string, unit => unit) => Js.Promise.t('a) =
 external selectAllEval : (string, unit => unit) => Js.Promise.t('a) =
   "$$eval";
 
-[@bs.send]
-external _addScriptTag : (t, tagOptions) => Js.Promise.t(ElementHandle.t) =
-  "addScriptTag";
+[@bs.send.pipe : t]
+external addScriptTag : tagOptions => Js.Promise.t(ElementHandle.t) =
+  "";
 
-let addScriptTag =
-    (
-      ~url: option(string)=?,
-      ~path: option(string)=?,
-      ~content: option(string)=?,
-      t
-    ) =>
-  _addScriptTag(t, makeTagOptions(~url?, ~path?, ~content?, ()));
 
-[@bs.send]
-external _addStyleTag : (t, tagOptions) => Js.Promise.t(ElementHandle.t) =
-  "addStyleTag";
-
-let addStyleTag =
-   (
-     ~url: option(string)=?,
-     ~path: option(string)=?,
-     ~content: option(string)=?,
-     t
-   ) =>
-  _addStyleTag(t, makeTagOptions(~url?, ~path?, ~content?, ()));
+[@bs.send.pipe : t]
+external addStyleTag : tagOptions => Js.Promise.t(ElementHandle.t) =
+  "";
 

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -84,3 +84,9 @@ external evaluate :
   (unit => Js.Promise.t(Js.Json.t), [@bs.splice] array({..})) =>
   Js.Promise.t(Js.Json.t) =
   "";
+
+[@bs.send.pipe :t]
+external evaluateHandle :
+  (unit => Js.Promise.t(JSHandle.t), [@bs.splice] array({..})) =>
+  Js.Promise.t(JSHandle.t) =
+  "";

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -82,3 +82,17 @@ let addScriptTag =
       t
     ) =>
   _addScriptTag(t, makeTagOptions(~url?, ~path?, ~content?, ()));
+
+[@bs.send]
+external _addStyleTag : (t, tagOptions) => Js.Promise.t(ElementHandle.t) =
+  "addStyleTag";
+
+let addStyleTag =
+   (
+     ~url: option(string)=?,
+     ~path: option(string)=?,
+     ~content: option(string)=?,
+     t
+   ) =>
+  _addStyleTag(t, makeTagOptions(~url?, ~path?, ~content?, ()));
+

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -2,6 +2,18 @@ type t;
 
 type serializable = Js.Json.t;
 
+type tagOptions = {
+  .
+  "content": Js.undefined(string),
+  "path": Js.undefined(string),
+  "url": Js.undefined(string)
+};
+
+[@bs.obj]
+external makeTagOptions :
+  (~url: string=?, ~path: string=?, ~content: string=?, unit) => _ =
+  "";
+
 [@bs.send.pipe : t]
 external selectOne :
   (~selector: string) => Js.Promise.t(Js.null(ElementHandle.t)) =
@@ -57,3 +69,16 @@ external selectOneEval : (string, unit => unit) => Js.Promise.t('a) =
 [@bs.send.pipe : t]
 external selectAllEval : (string, unit => unit) => Js.Promise.t('a) =
   "$$eval";
+
+[@bs.send]
+external _addScriptTag : (t, tagOptions) => Js.Promise.t(ElementHandle.t) =
+  "addScriptTag";
+
+let addScriptTag =
+    (
+      ~url: option(string)=?,
+      ~path: option(string)=?,
+      ~content: option(string)=?,
+      t
+    ) =>
+  _addScriptTag(t, makeTagOptions(~url?, ~path?, ~content?, ()));

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -79,3 +79,8 @@ external addScriptTag : tagOptions => Js.Promise.t(ElementHandle.t) =
 external addStyleTag : tagOptions => Js.Promise.t(ElementHandle.t) =
   "";
 
+[@bs.send.pipe : t]
+external evaluate :
+  (unit => Js.Promise.t(Js.Json.t), [@bs.splice] array({..})) =>
+  Js.Promise.t(Js.Json.t) =
+  "";

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -60,12 +60,12 @@ external waitForXPath :
   Js.Promise.t(ElementHandle.t) =
   "";
 
-/* TODP: Add support [, ...args] */
+/* TODO: Add support [, ...args] */
 [@bs.send.pipe : t]
 external selectOneEval : (string, unit => unit) => Js.Promise.t('a) =
   "$eval";
 
-/* TODP: Add support [, ...args] */
+/* TODO: Add support [, ...args] */
 [@bs.send.pipe : t]
 external selectAllEval : (string, unit => unit) => Js.Promise.t('a) =
   "$$eval";
@@ -79,12 +79,16 @@ external addScriptTag : tagOptions => Js.Promise.t(ElementHandle.t) =
 external addStyleTag : tagOptions => Js.Promise.t(ElementHandle.t) =
   "";
 
+/* TODO: Currently only ever work for functions taking no arguments,
+   and the second parameter array can only ever be empty */
 [@bs.send.pipe : t]
 external evaluate :
   (unit => Js.Promise.t(Js.Json.t), [@bs.splice] array({..})) =>
   Js.Promise.t(Js.Json.t) =
   "";
 
+/* TODO: Currently only ever work for functions taking no arguments,
+   and the second parameter array can only ever be empty */
 [@bs.send.pipe :t]
 external evaluateHandle :
   (unit => Js.Promise.t(JSHandle.t), [@bs.splice] array({..})) =>

--- a/src/Page.re
+++ b/src/Page.re
@@ -111,20 +111,12 @@ external emulate : emulateOption => Js.Promise.t(unit) = "";
 
 [@bs.send.pipe : t] external viewport : unit => viewport = "";
 
-[@bs.send]
-external _emulateMedia : (t, Js.Nullable.t(string)) => Js.Promise.t(unit) =
+[@bs.send.pipe : t]
+external emulateMedia :
+  ([@bs.string] [ | `screen | `print]) => Js.Promise.t(unit) =
+  "";
+
+[@bs.send.pipe : t]
+external emulateMediaDisable :
+  ([@bs.as {json|null|json}] _) => Js.Promise.t(unit) =
   "emulateMedia";
-
-type mediaType =
-  | Screen
-  | Print;
-
-let emulateMedia = (mediaType: option(mediaType), t) =>
-  switch mediaType {
-  | Some(v) =>
-    switch v {
-    | Screen => _emulateMedia(t, Js.Nullable.return("screen"))
-    | Print => _emulateMedia(t, Js.Nullable.return("print"))
-    }
-  | None => _emulateMedia(t, Js.Nullable.null)
-  };

--- a/src/Page.re
+++ b/src/Page.re
@@ -19,6 +19,9 @@ type pageEvents =
 type authOptions = {. "username": string, "password": string};
 
 [@bs.send.pipe : t]
+external authenticate : Js.Null.t(authOptions) => Js.Promise.t(unit) = "";
+
+[@bs.send.pipe : t]
 external click : (string, ~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
   "";
 

--- a/src/Page.re
+++ b/src/Page.re
@@ -18,6 +18,37 @@ type pageEvents =
 
 type authOptions = {. "username": string, "password": string};
 
+type cookie = {
+  .
+  "name": string,
+  "value": string,
+  "domain": Js.undefined(string),
+  "url": Js.undefined(string),
+  "path": Js.undefined(string),
+  "expires": Js.undefined(float),
+  "httpOnly": Js.undefined(Js.boolean),
+  "secure": Js.undefined(Js.boolean),
+  "session": Js.undefined(Js.boolean),
+  "sameSite": Js.undefined(string)
+};
+
+[@bs.obj]
+external makeCookie :
+  (
+    ~name: string,
+    ~value: string,
+    ~domain: string=?,
+    ~url: string=?,
+    ~path: string=?,
+    ~expires: float=?,
+    ~httpOnly: Js.boolean=?,
+    ~secure: Js.boolean=?,
+    ~session: Js.boolean=?,
+    ~sameSite: string=?,
+    unit
+  ) =>
+  _ =
+  "";
 [@bs.send.pipe : t]
 external authenticate : Js.Null.t(authOptions) => Js.Promise.t(unit) = "";
 
@@ -49,3 +80,12 @@ type typeOptions = {. "delay": float};
 [@bs.send.pipe : t]
 external type_ : (string, string, ~options: typeOptions=?, unit) => Js.Promise.t(unit) =
   "type";
+
+[@bs.send.pipe : t] [@bs.splice]
+external deleteCookie : array(cookie) => Js.Promise.t(unit) = "";
+
+[@bs.send.pipe : t] [@bs.splice]
+external cookies : array(string) => Js.Promise.t(array(cookie)) = "";
+
+[@bs.send.pipe : t] [@bs.splice]
+external setCookie : array(cookie) => Js.Promise.t(unit) = "";

--- a/src/Page.re
+++ b/src/Page.re
@@ -32,6 +32,22 @@ type cookie = {
   "sameSite": Js.undefined(string)
 };
 
+type viewport = {
+  .
+  "width": int,
+  "height": int,
+  "deviceScaleFactor": int,
+  "isMobile": Js.boolean,
+  "hasTouch": Js.boolean,
+  "isLandscape": Js.boolean
+};
+
+type emulateOption = {
+  .
+  "viewport": viewport,
+  "userAgent": string
+};
+
 [@bs.obj]
 external makeCookie :
   (
@@ -89,3 +105,8 @@ external cookies : array(string) => Js.Promise.t(array(cookie)) = "";
 
 [@bs.send.pipe : t] [@bs.splice]
 external setCookie : array(cookie) => Js.Promise.t(unit) = "";
+
+[@bs.send.pipe : t]
+external emulate : emulateOption => Js.Promise.t(unit) = "";
+
+[@bs.send.pipe : t] external viewport : unit => viewport = "";

--- a/src/Page.re
+++ b/src/Page.re
@@ -110,3 +110,21 @@ external setCookie : array(cookie) => Js.Promise.t(unit) = "";
 external emulate : emulateOption => Js.Promise.t(unit) = "";
 
 [@bs.send.pipe : t] external viewport : unit => viewport = "";
+
+[@bs.send]
+external _emulateMedia : (t, Js.Nullable.t(string)) => Js.Promise.t(unit) =
+  "emulateMedia";
+
+type mediaType =
+  | Screen
+  | Print;
+
+let emulateMedia = (mediaType: option(mediaType), t) =>
+  switch mediaType {
+  | Some(v) =>
+    switch v {
+    | Screen => _emulateMedia(t, Js.Nullable.return("screen"))
+    | Print => _emulateMedia(t, Js.Nullable.return("print"))
+    }
+  | None => _emulateMedia(t, Js.Nullable.null)
+  };

--- a/src/Puppeteer.re
+++ b/src/Puppeteer.re
@@ -12,6 +12,9 @@ type connectOptions = {
 [@bs.val] [@bs.module "puppeteer"]
 external launch : (~options: Launcher.launchOptions=?, unit) => Js.Promise.t(Browser.t) =
   "";
+
+[@bs.val] [@bs.module "puppeteer"]
+external defaultArgs : unit => array(string) = "";
 /*
  * TODO: Write bindings to these interfaces.
  *


### PR DESCRIPTION
Add supports for following bindings:

- [x] [Puppeteer.defaultArgs](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#puppeteerdefaultargs)
- [x] [FrameBase.$$eval](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#frameevalselector-pagefunction-args)
- [x] [FrameBase.$eval](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#frameevalselector-pagefunction-args) *(unit test only)*
- [x] [FrameBase. addScriptTag](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#frameaddscripttagoptions)
- [x] [FrameBase. addStyleTag](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#frameaddstyletagoptions)
- [x] [Page.authenticate](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pageauthenticatecredentials)
- [x] [Page.cookies](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pagecookiesurls)
- [x] [Page.setCookie](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pagesetcookiecookies)
- [x] [Page.deleteCookie](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pagedeletecookiecookies)
- [x] [Page.emulate](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pageemulateoptions)
- [x] [Page.viewport](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pageviewport)
- [x] [Page.emulateMedia](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#pageemulatemediamediatype) (divided to `Page.emulateMedia` and `Page.emulateMediaDisable`)
- [x] [FrameBase.evaluate](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#frameevaluatepagefunction-args)
- [x] [FrameBase.evaluateHandle](https://github.com/GoogleChrome/puppeteer/blob/v1.1.1/docs/api.md#frameevaluatehandlepagefunction-args) 

Fix #9 