### PR TITLE
add missing keys "env" and "devtools" to launchOptions

### DIFF
--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -487,7 +487,7 @@ describe("Page", () => {
         page^ |> Page.evaluateHandle(eval);
       }
       |> then_(jsHandler =>
-           jsHandler |> expect |> ExpectJs.toBeTruthy |> Js.Promise.resolve
+           jsHandler |> expect |> ExpectJs.toBeTruthy |> resolve
          )
     )
   );

--- a/src/Puppeteer.re
+++ b/src/Puppeteer.re
@@ -32,40 +32,19 @@ external executablePath : unit => string = "";
 
 type launchOptions = {
   .
-  /* Whether to ignore HTTPS errors during navigation. Defaults to false. */
-  "ignoreHTTPSErrors": Js.Nullable.t(Js.boolean),
-  /* Whether to run Chromium in headless mode. Defaults to true. */
-  "headless": Js.Nullable.t(Js.boolean),
-  /*
-   * Path to a Chromium executable to run instead of bundled Chromium. If
-   * executablePath is a relative path, then it is resolved relative to current
-   * working directory.
-   */
-  "executablePath": Js.Nullable.t(string),
-  /*
-   * Slows down Puppeteer operations by the specified amount of milliseconds.
-   * Useful so that you can see what is going on.
-   */
-  "slowMo": Js.Nullable.t(float),
-  /*
-   * Additional arguments to pass to the Chromium instance. List of Chromium
-   * flags can be found here.
-   */
-  "args": Js.Nullable.t(array(string)),
-  /* Close chrome process on Ctrl-C. Defaults to true. */
-  "handleSIGINT": Js.Nullable.t(Js.boolean),
-  /*
-   * Maximum time in milliseconds to wait for the Chrome instance to start.
-   * Defaults to 30000 (30 seconds). Pass 0 to disable timeout.
-   */
-  "timeout": Js.Nullable.t(int),
-  /*
-   * Whether to pipe browser process stdout and stderr into process.stdout and
-   * process.stderr. Defaults to false.
-   */
-  "dumpio": Js.Nullable.t(Js.boolean),
-  /* Path to a User Data Directory. */
-  "userDataDir": Js.Nullable.t(string),
+  "ignoreHTTPSErrors": Js.undefined(Js.boolean),
+  "headless": Js.undefined(Js.boolean),
+  "executablePath": Js.undefined(string),
+  "slowMo": Js.undefined(float),
+  "args": Js.undefined(array(string)),
+  "handleSIGINT": Js.undefined(Js.boolean),
+  "handleSIGTERM": Js.undefined(Js.boolean),
+  "handleSIGHUP": Js.undefined(Js.boolean),
+  "timeout": Js.undefined(int),
+  "dumpio": Js.undefined(Js.boolean),
+  "userDataDir": Js.undefined(string),
+  "env": Js.undefined(Js.Dict.t(string)),
+  "devtools": Js.undefined(Js.boolean),
 };
 
 [@bs.obj]
@@ -83,7 +62,7 @@ external makeLaunchOptions :
     ~timeout: float=?,
     ~dumpio: Js.boolean=?,
     ~userDataDir: string=?,
-    ~env: Js.t('a)=?,
+    ~env: Js.Dict.t(string)=?,
     ~devtools: Js.boolean=?,
     unit
   ) =>


### PR DESCRIPTION
The type `launchOptions` was missing `"env"` and `"devtools"` keys that were already present in the make function. Also properly types `"env"` as a `Js.Dict.t(string)`.