### PR TITLE
Fix tracing options and make Tracing.stop return a buffer

### DIFF
--- a/lib/js/src/Tracing.js
+++ b/lib/js/src/Tracing.js
@@ -1,1 +1,21 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */
+'use strict';
+
+var Util$BsPuppeteer = require("./Util.js");
+
+function makeTracingOptions(path, screenshots, categories, _) {
+  var tmp = { };
+  if (path) {
+    tmp.path = path[0];
+  }
+  var tmp$1 = Util$BsPuppeteer.optBoolToJs(screenshots);
+  if (tmp$1) {
+    tmp.screenshots = tmp$1[0];
+  }
+  if (categories) {
+    tmp.categories = categories[0];
+  }
+  return tmp;
+}
+
+exports.makeTracingOptions = makeTracingOptions;
+/* No side effect */

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "puppeteer": "^1.2.0-next.1523394876742"
+    "puppeteer": "^1.3"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.2",
     "bs-platform": "^2.2.3",
-    "husky": "^0.15.0-rc.12",
-    "lint-staged": "^7.0.0"
+    "husky": "^0.15.0-rc.13",
+    "lint-staged": "^7.0.4"
   }
 }

--- a/src/Tracing.re
+++ b/src/Tracing.re
@@ -2,21 +2,29 @@ type t;
 
 type tracingOptions = {
   .
-  "path": string,
-  "screenshots": Js.Nullable.t(bool),
-  "categories": array(string),
+  "path": Js.nullable(string),
+  "screenshots": Js.nullable(Js.boolean),
+  "categories": Js.nullable(array(string)),
 };
 
 [@bs.obj]
 external makeTracingOptions :
   (
     ~path: string=?,
-    ~screenshots: Js.Nullable.t(Js.boolean)=?,
+    ~screenshots: Js.boolean=?,
     ~categories: array(string)=?,
     unit
   ) =>
   tracingOptions =
   "";
+
+let makeTracingOptions = (~path=?, ~screenshots=?, ~categories=?, ()) =>
+  makeTracingOptions(
+    ~path?,
+    ~screenshots=?Util.optBoolToJs(screenshots),
+    ~categories?,
+    (),
+  );
 
 [@bs.send.pipe: t]
 external start : (~options: tracingOptions=?, unit) => Js.Promise.t(unit) =

--- a/src/Tracing.re
+++ b/src/Tracing.re
@@ -30,4 +30,5 @@ let makeTracingOptions = (~path=?, ~screenshots=?, ~categories=?, ()) =>
 external start : (~options: tracingOptions=?, unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send] external stop : t => Js.Promise.t(unit) = "";
+[@bs.send]
+external stop : t => Js.Promise.t(Js.Typed_array.ArrayBuffer.t) = "";


### PR DESCRIPTION
Upgrades us to Puppeteer 1.3.
Fixes `tracingOptions` and its creation function.
Return a buffer from `Tracing.stop()`.

Fixes #52.