### PR TITLE
Add ElementHandle.boxModel() and BoxModel module

### DIFF
--- a/lib/js/src/BoxModel.js
+++ b/lib/js/src/BoxModel.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/lib/js/src/ElementHandle.js
+++ b/lib/js/src/ElementHandle.js
@@ -4,4 +4,11 @@ var JSHandle$BsPuppeteer = require("./JSHandle.js");
 
 JSHandle$BsPuppeteer.Impl(/* module */[]);
 
+function boxModel(handle) {
+  return handle.boxModel().then((function (handle) {
+                return Promise.resolve((handle == null) ? /* None */0 : [handle]);
+              }));
+}
+
+exports.boxModel = boxModel;
 /*  Not a pure module */

--- a/src/BoxModel.re
+++ b/src/BoxModel.re
@@ -1,0 +1,17 @@
+type point = {
+  .
+  "x": float,
+  "y": float,
+};
+
+type quad = (point, point, point, point);
+
+type t = {
+  .
+  "content": quad,
+  "padding": quad,
+  "border": quad,
+  "margin": quad,
+  "width": float,
+  "height": float,
+};

--- a/src/ElementHandle.re
+++ b/src/ElementHandle.re
@@ -9,15 +9,6 @@ include
 
 external empty : unit => t = "%identity";
 
-[@bs.send.pipe: t]
-external selectOne : (~selector: string) => Js.Promise.t(Js.Null.t(t)) = "$";
-
-[@bs.send.pipe: t]
-external selectAll : (~selector: string) => Js.Promise.t(array(t)) = "$$";
-
-[@bs.send.pipe: t]
-external selectXPath : (~xpath: string) => Js.Promise.t(array(t)) = "$x";
-
 [@bs.send]
 external boundingBox : t => Js.Promise.t(Js.Null.t(BoundingBox.t)) = "";
 
@@ -39,6 +30,15 @@ external screenshot :
   (~options: Screenshot.options=?, unit) =>
   Js.Promise.t(Js.Typed_array.ArrayBuffer.t) =
   "";
+
+[@bs.send.pipe: t]
+external selectOne : (~selector: string) => Js.Promise.t(Js.Null.t(t)) = "$";
+
+[@bs.send.pipe: t]
+external selectAll : (~selector: string) => Js.Promise.t(array(t)) = "$$";
+
+[@bs.send.pipe: t]
+external selectXPath : (~xpath: string) => Js.Promise.t(array(t)) = "$x";
 
 [@bs.send] external tap : t => Js.Promise.t(unit) = "";
 

--- a/src/ElementHandle.re
+++ b/src/ElementHandle.re
@@ -12,6 +12,13 @@ external empty : unit => t = "%identity";
 [@bs.send]
 external boundingBox : t => Js.Promise.t(Js.Null.t(BoundingBox.t)) = "";
 
+[@bs.send]
+external boxModel : t => Js.Promise.t(Js.nullable(BoxModel.t)) = "";
+
+let boxModel = handle =>
+  boxModel(handle)
+  |> Js.Promise.(then_(handle => Js.toOption(handle) |> resolve));
+
 [@bs.send.pipe: t]
 external click : (~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
   "";


### PR DESCRIPTION
Adds a binding for the boxModel method and a type to represent the object that is returned.

Fixes #47.