### PR TITLE
Rename Target.pageType to targetType

### DIFF
--- a/lib/js/src/Target.js
+++ b/lib/js/src/Target.js
@@ -21,18 +21,24 @@ var jsMapperConstantArray = /* array */[
   ]
 ];
 
-function pageTypeToJs(param) {
+function targetTypeToJs(param) {
   return Js_mapperRt.binarySearch(4, param, jsMapperConstantArray);
 }
 
-function pageTypeFromJs(param) {
+function targetTypeFromJs(param) {
   return Js_mapperRt.revSearch(4, jsMapperConstantArray, param);
 }
 
 function type_(t) {
-  return pageTypeFromJs(t.type());
+  return targetTypeFromJs(t.type());
 }
 
+var pageTypeToJs = targetTypeToJs;
+
+var pageTypeFromJs = targetTypeFromJs;
+
+exports.targetTypeToJs = targetTypeToJs;
+exports.targetTypeFromJs = targetTypeFromJs;
 exports.pageTypeToJs = pageTypeToJs;
 exports.pageTypeFromJs = pageTypeFromJs;
 exports.type_ = type_;

--- a/src/Target.re
+++ b/src/Target.re
@@ -3,7 +3,16 @@ type t = Types.target;
 external empty : unit => t = "%identity";
 
 [@bs.deriving jsConverter]
-type pageType = [ | `page | `service_worker | `browser | `other];
+type targetType = [ | `page | `service_worker | `browser | `other];
+
+[@ocaml.deprecated "pageType has been renamed to targetType"]
+type pageType = targetType;
+
+[@ocaml.deprecated "pageTypeToJs has been renamed to targetTypeToJs"]
+let pageTypeToJs = targetTypeToJs;
+
+[@ocaml.deprecated "pageTypeFromJs has been renamed to targetTypeFromJs"]
+let pageTypeFromJs = targetTypeFromJs;
 
 [@bs.send] external browser : t => Types.browser = "";
 
@@ -13,6 +22,6 @@ type pageType = [ | `page | `service_worker | `browser | `other];
 
 [@bs.send] external typeString : t => string = "type";
 
-let type_ = t => t |> typeString |> pageTypeFromJs;
+let type_ = t => t |> typeString |> targetTypeFromJs;
 
 [@bs.send] external url : t => string = "";


### PR DESCRIPTION
In fact only one of the targets is a page, so this is more
appropriately called `targetType`. I prefer this over using `type_`
with the underscore to avoid the reserved word, and this way it
does not use the same name as the `type_` function.

Adds deprecations on `pageType` and its `bs.deriving` functions.