### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 language: node_js
 node_js:
   - 8
+addons:
+  apt:
+    packages:
+      # Needed for Chrome on Trusty
+      - libnss3
 cache:
   directories:
     - node_modules

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -36,11 +36,7 @@ let testPageCssPath = Node.Path.resolve(fixturesPath, "./testPage.css");
 
 let testPageContent = Node.Fs.readFileAsUtf8Sync(testPagePath);
 
-let noSandbox =
-  Puppeteer.makeLaunchOptions(
-    ~args=[|"--no-sandbox", "--disable-setuid-sandbox"|],
-    (),
-  );
+let noSandbox = Puppeteer.makeLaunchOptions(~args=[|"--no-sandbox"|], ());
 
 describe("Puppeteer", () => {
   test("executablePath", () =>

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -43,10 +43,7 @@ var testPageCssPath = Path.resolve(fixturesPath, "./testPage.css");
 var testPageContent = Fs.readFileSync(testPagePath, "utf8");
 
 var noSandbox = {
-  args: /* array */[
-    "--no-sandbox",
-    "--disable-setuid-sandbox"
-  ]
+  args: /* array */["--no-sandbox"]
 };
 
 describe("Puppeteer", (function () {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "puppeteer": "^1.6.0"
+    "puppeteer": "^1.6.1"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.2",


### PR DESCRIPTION
We started running into issues with CI builds in the last couple of days. This PR makes a couple of changes to make our testing setup more similar to that used by Puppeteer and bumps the required Puppeteer version to 1.6.1. I suspect Puppeteer 1.6.0 used a bad Chromium revision, and this seems to resolve the issue with Travis being unable to launch Chromium.