### PR TITLE
Add waitForRequest and waitForResponse functions

### DIFF
--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -6,6 +6,8 @@ open Expect;
 
 let seconds = v => v * 1000;
 
+[@bs.val] external fetch : string => Js.Promise.t(Response.t) = "";
+
 let getElementValueJs: Dom.element => string = [%raw
   {| function (element) { return element.value; } |}
 ];
@@ -287,6 +289,17 @@ describe("Page", () => {
          )
     )
   );
+  /* TODO: Run a test http server so these fetches can actually work. */
+  Skip.testPromise("waitForResponseUrl()", () => {
+    let url = "file:///" ++ testPagePath;
+    Js.Promise.all2((
+      page^ |. Page.waitForResponseUrl(url, ()),
+      page^ |> Page.evaluate(() => fetch("/testPage.html")),
+    ))
+    |> Js.Promise.then_(((res, _)) =>
+         res |> Response.url |> expect |> toEqual(url) |> Js.Promise.resolve
+       );
+  });
   testPromise("waitForSelector()", () =>
     Js.Promise.(
       page^

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -13,6 +13,7 @@ var Caml_array = require("bs-platform/lib/js/caml_array.js");
 var Caml_int32 = require("bs-platform/lib/js/caml_int32.js");
 var Pervasives = require("bs-platform/lib/js/pervasives.js");
 var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
+var Page$BsPuppeteer = require("../src/Page.js");
 var Unit$BsPuppeteer = require("../src/Unit.js");
 var Target$BsPuppeteer = require("../src/Target.js");
 var Coverage$BsPuppeteer = require("../src/Coverage.js");
@@ -203,6 +204,17 @@ describe("Page", (function () {
         Jest.testPromise(undefined, "screenshot()", (function () {
                 return page[0].screenshot(undefined).then((function (buf) {
                               return Promise.resolve(Jest.Expect[/* toBeGreaterThanOrEqual */6](3236, Jest.Expect[/* expect */0](buf.toString().length)));
+                            }));
+              }));
+        it.skip(undefined, "waitForResponseUrl()", (function () {
+                var url = "file:///" + testPagePath;
+                return Promise.all(/* tuple */[
+                              Page$BsPuppeteer.waitForResponseUrl(page[0], url, undefined, /* () */0),
+                              page[0].evaluate((function () {
+                                      return fetch("/testPage.html");
+                                    }))
+                            ]).then((function (param) {
+                              return Promise.resolve(Jest.Expect[/* toEqual */12](url, Jest.Expect[/* expect */0](param[0].url())));
                             }));
               }));
         Jest.testPromise(undefined, "waitForSelector()", (function () {

--- a/lib/js/src/Page.js
+++ b/lib/js/src/Page.js
@@ -13,6 +13,42 @@ function waitForNavigation(options, page) {
               }));
 }
 
+var WaitForRequest = /* module */[];
+
+var WaitForResponse = /* module */[];
+
+function waitForRequest(prim, prim$1, prim$2, _) {
+  return prim.waitForRequest(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
+}
+
+function waitForRequestRe(prim, prim$1, prim$2, _) {
+  return prim.waitForRequest(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
+}
+
+function waitForRequestUrl(prim, prim$1, prim$2, _) {
+  return prim.waitForRequest(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
+}
+
+function waitForResponse(prim, prim$1, prim$2, _) {
+  return prim.waitForResponse(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
+}
+
+function waitForResponseRe(prim, prim$1, prim$2, _) {
+  return prim.waitForResponse(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
+}
+
+function waitForResponseUrl(prim, prim$1, prim$2, _) {
+  return prim.waitForResponse(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
+}
+
 exports.setBypassCSP = setBypassCSP;
 exports.waitForNavigation = waitForNavigation;
+exports.WaitForRequest = WaitForRequest;
+exports.WaitForResponse = WaitForResponse;
+exports.waitForRequest = waitForRequest;
+exports.waitForRequestRe = waitForRequestRe;
+exports.waitForRequestUrl = waitForRequestUrl;
+exports.waitForResponse = waitForResponse;
+exports.waitForResponseRe = waitForResponseRe;
+exports.waitForResponseUrl = waitForResponseUrl;
 /* FrameBase-BsPuppeteer Not a pure module */

--- a/src/Page.re
+++ b/src/Page.re
@@ -318,4 +318,61 @@ let waitForNavigation = (~options, page) =>
   waitForNavigation(~options, page)
   |> Js.Promise.(then_(response => response |> Js.toOption |> resolve));
 
+module WaitForRequest = {
+  [@bs.deriving abstract]
+  type options = {
+    [@bs.optional]
+    timeout: float,
+  };
+
+  [@bs.send]
+  external waitForRequest :
+    (t, Request.t => bool, ~options: options=?, unit) =>
+    Js.Promise.t(Request.t) =
+    "";
+
+  [@bs.send]
+  external waitForRequestRe :
+    (t, Request.t => Js.Re.t, ~options: options=?, unit) =>
+    Js.Promise.t(Request.t) =
+    "waitForRequest";
+
+  [@bs.send]
+  external waitForRequestUrl :
+    (t, string, ~options: options=?, unit) => Js.Promise.t(Request.t) =
+    "waitForRequest";
+};
+
+module WaitForResponse = {
+  [@bs.deriving abstract]
+  type options = {
+    [@bs.optional]
+    timeout: float,
+  };
+
+  [@bs.send]
+  external waitForResponse :
+    (t, Response.t => bool, ~options: options=?, unit) =>
+    Js.Promise.t(Response.t) =
+    "";
+
+  [@bs.send]
+  external waitForResponseRe :
+    (t, Response.t => Js.Re.t, ~options: options=?, unit) =>
+    Js.Promise.t(Response.t) =
+    "waitForResponse";
+
+  [@bs.send]
+  external waitForResponseUrl :
+    (t, string, ~options: options=?, unit) => Js.Promise.t(Response.t) =
+    "waitForResponse";
+};
+
+let waitForRequest = WaitForRequest.waitForRequest;
+let waitForRequestRe = WaitForRequest.waitForRequestRe;
+let waitForRequestUrl = WaitForRequest.waitForRequestUrl;
+let waitForResponse = WaitForResponse.waitForResponse;
+let waitForResponseRe = WaitForResponse.waitForResponseRe;
+let waitForResponseUrl = WaitForResponse.waitForResponseUrl;
+
 [@bs.send] external workers : t => array(Worker.t) = "";


### PR DESCRIPTION
Adds the following functions to Page:

- `waitForRequest`
- `waitForRequestRe`
- `waitForRequestUrl`
- `waitForResponse`
- `waitForResponseRe`
- `waitForResponseUrl`

Adds one currently skipped test for `waitForResponseUrl` which won't pass until we run an HTTP server during the test run so that the fetch can succeed. Until then it demonstrates that it generates the right code.

Fixes #64.