### PR TITLE
Fix Page.viewport and Page.emulate

### DIFF
--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -453,36 +453,24 @@ describe("Page", () => {
       |> then_(cookies => cookies |> expect |> toHaveLength(0) |> resolve)
     )
   );
-  testPromise("emulate()", () =>
+  testPromise("emulate()", () => {
+    module V = Page.Viewport;
+    let viewport =
+      V.make(
+        ~width=320,
+        ~height=480,
+        ~deviceScaleFactor=2.,
+        ~hasTouch=true,
+        (),
+      );
     Js.Promise.(
       page^
-      |> Page.emulate({
-           "viewport": {
-             "width": 320,
-             "height": 480,
-             "deviceScaleFactor": 2.,
-             "isMobile": true,
-             "hasTouch": true,
-             "isLandscape": true,
-           },
-           "userAgent": "",
-         })
+      |> Page.emulate({"viewport": viewport, "userAgent": ""})
       |> then_(() =>
-           page^
-           |> Page.viewport()
-           |> expect
-           |> ExpectJs.toMatchObject({
-                "width": 320,
-                "height": 480,
-                "deviceScaleFactor": 2.,
-                "isMobile": true,
-                "hasTouch": true,
-                "isLandscape": true,
-              })
-           |> resolve
+           expect(Page.viewport(page^)) |> toEqual(viewport) |> resolve
          )
-    )
-  );
+    );
+  });
   testPromise("emulateMedia()", () =>
     Js.Promise.(
       page^ |> Page.emulateMedia(`print) |> then_(() => pass |> resolve)

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -454,9 +454,8 @@ describe("Page", () => {
     )
   );
   testPromise("emulate()", () => {
-    module V = Page.Viewport;
     let viewport =
-      V.make(
+      Page.Viewport.make(
         ~width=320,
         ~height=480,
         ~deviceScaleFactor=2.,

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -325,7 +325,7 @@ describe("Page", (function () {
                             }));
               }));
         Jest.testPromise(undefined, "emulate()", (function () {
-                var viewport = Curry._7(Page$BsPuppeteer.Viewport[/* make */0], 320, 480, 2, undefined, true, undefined, /* () */0);
+                var viewport = Page$BsPuppeteer.Viewport[/* make */0](320, 480, 2, undefined, true, undefined, /* () */0);
                 return page[0].emulate({
                               viewport: viewport,
                               userAgent: ""

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -325,25 +325,12 @@ describe("Page", (function () {
                             }));
               }));
         Jest.testPromise(undefined, "emulate()", (function () {
+                var viewport = Curry._7(Page$BsPuppeteer.Viewport[/* make */0], 320, 480, 2, undefined, true, undefined, /* () */0);
                 return page[0].emulate({
-                              viewport: {
-                                width: 320,
-                                height: 480,
-                                deviceScaleFactor: 2,
-                                isMobile: true,
-                                hasTouch: true,
-                                isLandscape: true
-                              },
+                              viewport: viewport,
                               userAgent: ""
                             }).then((function () {
-                              return Promise.resolve(Jest.ExpectJs[/* toMatchObject */31]({
-                                              width: 320,
-                                              height: 480,
-                                              deviceScaleFactor: 2,
-                                              isMobile: true,
-                                              hasTouch: true,
-                                              isLandscape: true
-                                            }, Jest.Expect[/* expect */0](page[0].viewport())));
+                              return Promise.resolve(Jest.Expect[/* toEqual */12](viewport, Jest.Expect[/* expect */0](page[0].viewport())));
                             }));
               }));
         Jest.testPromise(undefined, "emulateMedia()", (function () {

--- a/lib/js/src/Page.js
+++ b/lib/js/src/Page.js
@@ -3,6 +3,28 @@
 var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 var FrameBase$BsPuppeteer = require("./FrameBase.js");
 
+function make(prim, prim$1, prim$2, prim$3, prim$4, prim$5, _) {
+  var tmp = {
+    width: prim,
+    height: prim$1
+  };
+  if (prim$2 !== undefined) {
+    tmp.deviceScaleFactor = Js_primitive.valFromOption(prim$2);
+  }
+  if (prim$3 !== undefined) {
+    tmp.isMobile = Js_primitive.valFromOption(prim$3);
+  }
+  if (prim$4 !== undefined) {
+    tmp.hasTouch = Js_primitive.valFromOption(prim$4);
+  }
+  if (prim$5 !== undefined) {
+    tmp.isLandscape = Js_primitive.valFromOption(prim$5);
+  }
+  return tmp;
+}
+
+var Viewport = /* module */[/* make */make];
+
 function setBypassCSP(enabled, page) {
   return page.setBypassCSP(enabled);
 }
@@ -41,6 +63,7 @@ function waitForResponseUrl(prim, prim$1, prim$2, _) {
   return prim.waitForResponse(prim$1, prim$2 !== undefined ? Js_primitive.valFromOption(prim$2) : undefined);
 }
 
+exports.Viewport = Viewport;
 exports.setBypassCSP = setBypassCSP;
 exports.waitForNavigation = waitForNavigation;
 exports.WaitForRequest = WaitForRequest;

--- a/src/Page.re
+++ b/src/Page.re
@@ -36,21 +36,34 @@ type cookie = {
   "sameSite": Js.undefined(string),
 };
 
-type viewport = {
-  .
-  "width": int,
-  "height": int,
-  "deviceScaleFactor": float,
-  "isMobile": bool,
-  "hasTouch": bool,
-  "isLandscape": bool,
+module Viewport = {
+  [@bs.deriving abstract]
+  type t = {
+    width: int,
+    height: int,
+    [@bs.optional]
+    deviceScaleFactor: float,
+    [@bs.optional]
+    isMobile: bool,
+    [@bs.optional]
+    hasTouch: bool,
+    [@bs.optional]
+    isLandscape: bool,
+  };
+
+  let make = t;
 };
 
-type emulateOption = {
+type viewport = Viewport.t;
+
+type emulateOptions = {
   .
   "viewport": viewport,
   "userAgent": string,
 };
+
+[@ocaml.deprecated "emulateOption has been renamed emulateOptions"]
+type emulateOption = emulateOptions;
 
 type margin = {
   .
@@ -228,9 +241,9 @@ external cookies : array(string) => Js.Promise.t(array(cookie)) = "";
 external setCookie : array(cookie) => Js.Promise.t(unit) = "";
 
 [@bs.send.pipe: t]
-external emulate : emulateOption => Js.Promise.t(unit) = "";
+external emulate : emulateOptions => Js.Promise.t(unit) = "";
 
-[@bs.send.pipe: t] external viewport : unit => viewport = "";
+[@bs.send.pipe: t] external viewport : viewport = "";
 
 [@bs.send.pipe: t]
 external emulateMedia :


### PR DESCRIPTION
Cleanup of code associated with the Page.viewport type.

- Make all fields in viewport optional except for width and height.
- Construct the viewport using bs.deriving abstract.
- Introduce Page.Viewport module for this type.
- Remove unnecessary unit argument to Page.viewport().
- Rename Page.emulateOption to emulateOptions.