### PR TITLE
Convert to object-first convention for use with fast pipe

### DIFF
--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -610,7 +610,7 @@ describe("Page", () => {
     page^ |> Page.target |> Target.url |> expect |> toBe("about:blank")
   );
   test("coverage", () =>
-    page^ |> Page.coverage |> expect |> ExpectJs.toBeTruthy
+    Page.coverage(page^) |> expect |> ExpectJs.toBeTruthy
   );
   afterAllPromise(() =>
     Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
@@ -783,17 +783,12 @@ describe("Coverage", () => {
         browser^
         |> Browser.newPage
         |> then_(page => {
-             let coverage = page |> Page.coverage;
-             coverage
-             |> Coverage.startJSCoverage(
-                  ~options=
-                    Coverage.makeJSCoverageOptions(
-                      ~resetOnNavigation=true,
-                      (),
-                    ),
-                )
+             let coverage = page->Page.coverage;
+             let options =
+               Coverage.makeJSCoverageOptions(~resetOnNavigation=true, ());
+             coverage->Coverage.startJSCoverage(~options, ())
              |> then_(() => page |> Page.goto("file://" ++ testPagePath, ()))
-             |> then_(_res => coverage |> Coverage.stopJSCoverage)
+             |> then_(_res => Coverage.stopJSCoverage(coverage))
              |> then_(res => {
                   report := res;
                   res |> resolve;
@@ -833,20 +828,14 @@ describe("Coverage", () => {
     let report = ref([||]);
     beforeAllPromise(() =>
       Js.Promise.(
-        browser^
-        |> Browser.newPage
+        (browser^)->Browser.newPage
         |> then_(page => {
-             let coverage = page |> Page.coverage;
-             coverage
-             |> Coverage.startCSSCoverage(
-                  ~options=
-                    Coverage.makeCSSCoverageOptions(
-                      ~resetOnNavigation=true,
-                      (),
-                    ),
-                )
+             let coverage = page->Page.coverage;
+             let options =
+               Coverage.makeCSSCoverageOptions(~resetOnNavigation=true, ());
+             coverage->Coverage.startCSSCoverage(~options, ())
              |> then_(() => page |> Page.goto("file://" ++ testPagePath, ()))
-             |> then_(_res => coverage |> Coverage.stopCSSCoverage)
+             |> then_(_res => coverage->Coverage.stopCSSCoverage)
              |> then_(res => {
                   report := res;
                   res |> resolve;

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -217,15 +217,13 @@ describe("Page", () => {
   );
   testPromise("$$eval()", () =>
     Js.Promise.(
-      page^
-      |> Page.selectAllEval("html,body", getLengthOfElementsJs)
+      (page^)->Page.selectAllEval("html,body", getLengthOfElementsJs)
       |> then_(length => length |> expect |> toBe(2.0) |> resolve)
     )
   );
   testPromise("$eval() with 0 args", () =>
     Js.Promise.(
-      page^
-      |> Page.selectOneEval("html", getElementOuterHTMLJs)
+      (page^)->Page.selectOneEval("html", getElementOuterHTMLJs)
       |> then_(html =>
            html
            |> expect
@@ -236,8 +234,7 @@ describe("Page", () => {
   );
   testPromise("$eval() with 0 args returning a promise", () =>
     Js.Promise.(
-      page^
-      |> Page.selectOneEvalPromise("html", getElementOuterHTMLJsPromise)
+      (page^)->Page.selectOneEvalPromise("html", getElementOuterHTMLJsPromise)
       |> then_(h =>
            h
            |> expect
@@ -251,21 +248,21 @@ describe("Page", () => {
       page^
       |> Page.setContent(testPageContent)
       |> then_(() =>
-           page^
-           |> Page.selectOneEval1(
-                "input",
-                [%raw
-                  {| function (el, prop) { return el.getAttribute(prop); } |}
-                ],
-                "id",
-              )
+           (page^)
+           ->Page.selectOneEval1(
+               "input",
+               [%raw
+                 {| function (el, prop) { return el.getAttribute(prop); } |}
+               ],
+               "id",
+             )
          )
       |> then_(id => id |> expect |> toBe("input") |> resolve)
     )
   );
   testPromise("click()", () =>
     Js.Promise.(
-      page^ |> Page.click("body", ()) |> then_(() => pass |> resolve)
+      (page^)->Page.click("body", ()) |> then_(() => pass |> resolve)
     )
   );
   testPromise("goto()", () =>
@@ -312,19 +309,18 @@ describe("Page", () => {
   });
   testPromise("waitForSelector()", () =>
     Js.Promise.(
-      page^
-      |> Page.waitForSelector("body", ())
+      (page^)->Page.waitForSelector("body", ())
       |> then_(() => pass |> resolve)
     )
   );
   testPromise("waitForXPath()", () =>
     Js.Promise.(
-      page^
-      |> Page.waitForXPath(
-           ~xpath="/html/body",
-           ~options=Page.makeSelectorOptions(~timeout=100., ()),
-           (),
-         )
+      (page^)
+      ->Page.waitForXPath(
+          ~xpath="/html/body",
+          ~options=Page.makeSelectorOptions(~timeout=100., ()),
+          (),
+        )
       |> then_(elementHandle =>
            elementHandle |> expect |> ExpectJs.toBeTruthy |> resolve
          )
@@ -348,9 +344,9 @@ describe("Page", () => {
       |> then_(page =>
            page
            |> Page.setContent(testPageContent)
-           |> then_(() => page |> Page.type_("#input", "hello world", ()))
+           |> then_(() => page->Page.type_("#input", "hello world", ()))
            |> then_(() =>
-                page |> Page.selectOneEval("#input", getElementValueJs)
+                page->Page.selectOneEval("#input", getElementValueJs)
               )
          )
       |> then_(value => value |> expect |> toBe("hello world") |> resolve)
@@ -362,9 +358,7 @@ describe("Page", () => {
       |> Browser.newPage
       |> then_(page =>
            page
-           |> Page.addScriptTag(
-                Page.makeTagOptions(~path=testPageJsPath, ()),
-              )
+           ->Page.addScriptTag(Page.makeTagOptions(~path=testPageJsPath, ()))
            |> then_(_elementHandle => Page.content(page))
            |> then_(content =>
                 Page.close(page)
@@ -380,13 +374,10 @@ describe("Page", () => {
   );
   testPromise("addStyleTag()", () =>
     Js.Promise.(
-      browser^
-      |> Browser.newPage
+      Browser.newPage(browser^)
       |> then_(page =>
            page
-           |> Page.addStyleTag(
-                Page.makeTagOptions(~path=testPageCssPath, ()),
-              )
+           ->Page.addStyleTag(Page.makeTagOptions(~path=testPageCssPath, ()))
            |> then_(_elementHandle => Page.content(page))
            |> then_(content =>
                 Page.close(page)

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -304,7 +304,7 @@ describe("Page", () => {
     let url = "file:///" ++ testPagePath;
     Js.Promise.all2((
       (page^)->Page.waitForResponseUrl(url, ()),
-      page^ |> Page.evaluate(() => fetch("/testPage.html")),
+      (page^)->Page.evaluate(() => fetch("/testPage.html")),
     ))
     |> Js.Promise.then_(((res, _)) =>
          res |> Response.url |> expect |> toEqual(url) |> Js.Promise.resolve
@@ -496,7 +496,7 @@ describe("Page", () => {
     Js.Promise.(
       {
         let eval = () => "ok";
-        page^ |> Page.evaluate(eval);
+        (page^)->Page.evaluate(eval);
       }
       |> then_(res => res |> expect |> toBe("ok") |> resolve)
     )
@@ -505,7 +505,7 @@ describe("Page", () => {
     Js.Promise.(
       {
         let eval = arg => arg ++ "iedoke";
-        page^ |> Page.evaluate1(eval, "ok");
+        (page^)->Page.evaluate1(eval, "ok");
       }
       |> then_(res => res |> expect |> toBe("okiedoke") |> resolve)
     )
@@ -514,7 +514,7 @@ describe("Page", () => {
     Js.Promise.(
       {
         let eval = (arg1, arg2) => arg1 ++ " " ++ arg2;
-        page^ |> Page.evaluate1(eval("hello"), "world");
+        (page^)->Page.evaluate1(eval("hello"), "world");
       }
       |> then_(res => res |> expect |> toBe("hello world") |> resolve)
     )
@@ -523,7 +523,7 @@ describe("Page", () => {
     Js.Promise.(
       {
         let eval = (arg1, arg2) => resolve(arg1 ++ " " ++ arg2);
-        page^ |> Page.evaluatePromise1(eval("hello"), "world");
+        (page^)->Page.evaluatePromise1(eval("hello"), "world");
       }
       |> then_(res => res |> expect |> toBe("hello world") |> resolve)
     )
@@ -532,7 +532,7 @@ describe("Page", () => {
     Js.Promise.(
       {
         let eval = (arg1, arg2, arg3) => resolve(arg1 ++ " " ++ arg2 ++ arg3);
-        page^ |> Page.evaluatePromise2(eval("hello"), "world", "!");
+        (page^)->Page.evaluatePromise2(eval("hello"), "world", "!");
       }
       |> then_(res => res |> expect |> toBe("hello world!") |> resolve)
     )
@@ -542,7 +542,7 @@ describe("Page", () => {
       {
         let eval = (arg1, arg2) =>
           (arg1 |> String.length |> Js.Int.toString) ++ arg1 ++ " " ++ arg2;
-        page^ |> Page.evaluate2(eval, "hello", "world");
+        (page^)->Page.evaluate2(eval, "hello", "world");
       }
       |> then_(res => res |> expect |> toBe("5hello world") |> resolve)
     )
@@ -552,8 +552,7 @@ describe("Page", () => {
     page^
     |> Page.setContent(testPageContent)
     |> Js.Promise.then_(() =>
-         page^
-         |> Page.evaluateString(getTitleStr)
+         (page^)->Page.evaluateString(getTitleStr)
          |> Js.Promise.then_(title =>
               title |> expect |> toBe("Test Page") |> Js.Promise.resolve
             )
@@ -563,7 +562,7 @@ describe("Page", () => {
     Js.Promise.(
       {
         let eval = () => [%raw {| document |}];
-        page^ |> Page.evaluateHandle(eval);
+        (page^)->Page.evaluateHandle(eval);
       }
       |> then_(jsHandler =>
            jsHandler |> expect |> ExpectJs.toBeTruthy |> resolve

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -245,8 +245,7 @@ describe("Page", () => {
   );
   testPromise("$eval() with 1 arg", () =>
     Js.Promise.(
-      page^
-      |> Page.setContent(testPageContent)
+      (page^)->Page.setContent(testPageContent)
       |> then_(() =>
            (page^)
            ->Page.selectOneEval1(
@@ -271,7 +270,7 @@ describe("Page", () => {
       |> Browser.newPage
       |> then_(page => {
            let options = Navigation.makeOptions(~timeout=25000., ());
-           page |> Page.goto("file://" ++ testPagePath, ~options, ());
+           page->Page.goto("file://" ++ testPagePath, ~options, ());
          })
       |> then_(res => res |> Js.Null.getExn |> Response.text)
       |> then_(text =>
@@ -284,8 +283,7 @@ describe("Page", () => {
   );
   testPromise("screenshot()", () =>
     Js.Promise.(
-      page^
-      |> Page.screenshot()
+      (page^)->Page.screenshot()
       |> then_(buf =>
            buf
            |> Node.Buffer.toString
@@ -328,11 +326,11 @@ describe("Page", () => {
   );
   testPromise("setExtraHTTPHeaders", () =>
     Js.Promise.(
-      page^
-      |> Page.setExtraHTTPHeaders(
-           ~headers=Js.Dict.fromList([("extra-http-header", "header01")]),
-           (),
-         )
+      (page^)
+      ->Page.setExtraHTTPHeaders(
+          ~headers=Js.Dict.fromList([("extra-http-header", "header01")]),
+          (),
+        )
       /* TODO: Better way to verify extra HTTP headers */
       |> then_(() => pass |> resolve)
     )
@@ -342,8 +340,7 @@ describe("Page", () => {
       browser^
       |> Browser.newPage
       |> then_(page =>
-           page
-           |> Page.setContent(testPageContent)
+           page->Page.setContent(testPageContent)
            |> then_(() => page->Page.type_("#input", "hello world", ()))
            |> then_(() =>
                 page->Page.selectOneEval("#input", getElementValueJs)
@@ -402,55 +399,55 @@ describe("Page", () => {
   );
   testPromise("cookies()", () =>
     Js.Promise.(
-      page^
-      |> Page.setCookie([|
-           Page.makeCookie(
-             ~name="foo",
-             ~value="bar",
-             ~url="http://localhost",
-             (),
-           ),
-         |])
-      |> then_(() => page^ |> Page.cookies([|"http://localhost"|]))
+      (page^)
+      ->Page.setCookie([|
+          Page.makeCookie(
+            ~name="foo",
+            ~value="bar",
+            ~url="http://localhost",
+            (),
+          ),
+        |])
+      |> then_(() => (page^)->Page.cookies([|"http://localhost"|]))
       |> then_(cookies => cookies |> expect |> toHaveLength(1) |> resolve)
     )
   );
   testPromise("setCookie()", () =>
     Js.Promise.(
-      page^
-      |> Page.setCookie([|
-           Page.makeCookie(
-             ~name="foo",
-             ~value="bar",
-             ~url="http://localhost",
-             (),
-           ),
-           Page.makeCookie(
-             ~name="foo2",
-             ~value="bar2",
-             ~url="http://localhost2",
-             (),
-           ),
-         |])
+      (page^)
+      ->Page.setCookie([|
+          Page.makeCookie(
+            ~name="foo",
+            ~value="bar",
+            ~url="http://localhost",
+            (),
+          ),
+          Page.makeCookie(
+            ~name="foo2",
+            ~value="bar2",
+            ~url="http://localhost2",
+            (),
+          ),
+        |])
       |> then_(() =>
-           page^ |> Page.cookies([|"http://localhost", "http://localhost2"|])
+           (page^)->Page.cookies([|"http://localhost", "http://localhost2"|])
          )
       |> then_(cookies => cookies |> expect |> toHaveLength(2) |> resolve)
     )
   );
   testPromise("deleteCookie()", () =>
     Js.Promise.(
-      page^
-      |> Page.setCookie([|
-           Page.makeCookie(
-             ~name="foo",
-             ~value="bar",
-             ~url="http://localhost",
-             (),
-           ),
-         |])
-      |> then_(() => page^ |> Page.deleteCookie([||]))
-      |> then_(() => page^ |> Page.cookies([||]))
+      (page^)
+      ->Page.setCookie([|
+          Page.makeCookie(
+            ~name="foo",
+            ~value="bar",
+            ~url="http://localhost",
+            (),
+          ),
+        |])
+      |> then_(() => (page^)->Page.deleteCookie([||]))
+      |> then_(() => (page^)->Page.cookies([||]))
       |> then_(cookies => cookies |> expect |> toHaveLength(0) |> resolve)
     )
   );
@@ -464,8 +461,7 @@ describe("Page", () => {
         (),
       );
     Js.Promise.(
-      page^
-      |> Page.emulate({"viewport": viewport, "userAgent": ""})
+      (page^)->Page.emulate({"viewport": viewport, "userAgent": ""})
       |> then_(() =>
            expect(Page.viewport(page^) |> Js.Option.getExn)
            |> toEqual(viewport)
@@ -475,12 +471,12 @@ describe("Page", () => {
   });
   testPromise("emulateMedia()", () =>
     Js.Promise.(
-      page^ |> Page.emulateMedia(`print) |> then_(() => pass |> resolve)
+      (page^)->Page.emulateMedia(`print) |> then_(() => pass |> resolve)
     )
   );
   testPromise("emulateMediaDisable()", () =>
     Js.Promise.(
-      page^ |> Page.emulateMediaDisable |> then_(() => pass |> resolve)
+      Page.emulateMediaDisable(page^) |> then_(() => pass |> resolve)
     )
   );
   testPromise("evaluate()", () =>
@@ -540,8 +536,7 @@ describe("Page", () => {
   );
   testPromise("evaluateString()", () => {
     let getTitleStr = {| document.getElementsByTagName("title")[0].innerHTML; |};
-    page^
-    |> Page.setContent(testPageContent)
+    (page^)->Page.setContent(testPageContent)
     |> Js.Promise.then_(() =>
          (page^)->Page.evaluateString(getTitleStr)
          |> Js.Promise.then_(title =>
@@ -562,30 +557,30 @@ describe("Page", () => {
   );
   testPromise("pdf()", () =>
     Js.Promise.(
-      page^
-      |> Page.pdf(
-           Page.makePDFOptions(
-             ~scale=1.,
-             ~displayHeaderFooter=true,
-             ~headerTemplate="[[header]]",
-             ~footerTemplate="[[footer]]",
-             ~printBackground=true,
-             ~landscape=true,
-             ~pageRanges="",
-             ~format=`A0,
-             ~width=10.0 |> Unit.cm,
-             ~height=200.0 |> Unit.mm,
-             ~margin=
-               Page.makeMargin(
-                 ~top=0.1 |> Unit.cm,
-                 ~right=10.0 |> Unit.px,
-                 ~bottom=1.0 |> Unit.mm,
-                 ~left=0.01 |> Unit.in_,
-                 (),
-               ),
-             (),
-           ),
-         )
+      (page^)
+      ->Page.pdf(
+          Page.makePDFOptions(
+            ~scale=1.,
+            ~displayHeaderFooter=true,
+            ~headerTemplate="[[header]]",
+            ~footerTemplate="[[footer]]",
+            ~printBackground=true,
+            ~landscape=true,
+            ~pageRanges="",
+            ~format=`A0,
+            ~width=10.0 |> Unit.cm,
+            ~height=200.0 |> Unit.mm,
+            ~margin=
+              Page.makeMargin(
+                ~top=0.1 |> Unit.cm,
+                ~right=10.0 |> Unit.px,
+                ~bottom=1.0 |> Unit.mm,
+                ~left=0.01 |> Unit.in_,
+                (),
+              ),
+            (),
+          ),
+        )
       |> then_(buffer =>
            buffer
            |> Node.Buffer.toString
@@ -620,7 +615,7 @@ describe("ElementHandle", () => {
          })
       |> then_(res => {
            page := res;
-           page^ |> Page.goto("file://" ++ testPagePath, ());
+           (page^)->Page.goto("file://" ++ testPagePath, ());
          })
       |> then_(_resp => Page.selectOne(page^, ~selector="#iframe"))
       |> then_(res =>
@@ -777,7 +772,7 @@ describe("Coverage", () => {
              let options =
                Coverage.makeJSCoverageOptions(~resetOnNavigation=true, ());
              coverage->Coverage.startJSCoverage(~options, ())
-             |> then_(() => page |> Page.goto("file://" ++ testPagePath, ()))
+             |> then_(() => page->Page.goto("file://" ++ testPagePath, ()))
              |> then_(_res => Coverage.stopJSCoverage(coverage))
              |> then_(res => {
                   report := res;
@@ -824,7 +819,7 @@ describe("Coverage", () => {
              let options =
                Coverage.makeCSSCoverageOptions(~resetOnNavigation=true, ());
              coverage->Coverage.startCSSCoverage(~options, ())
-             |> then_(() => page |> Page.goto("file://" ++ testPagePath, ()))
+             |> then_(() => page->Page.goto("file://" ++ testPagePath, ()))
              |> then_(_res => coverage->Coverage.stopCSSCoverage)
              |> then_(res => {
                   report := res;

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -724,13 +724,12 @@ describe("CDPSession", () => {
     Js.Promise.(
       browser^
       |> Browser.newPage
-      |> then_(page => page |> Page.target |> Target.createCDPSession)
+      |> then_(page => page->Page.target->Target.createCDPSession)
       |> then_(session =>
            session
            |> CDPSession.detach
            |> then_(() =>
-                session
-                |> CDPSession.send(~method_="Animation.getPlaybackRate")
+                session->CDPSession.send("Animation.getPlaybackRate", ())
               )
            |> then_(_res =>
                 failwith(
@@ -746,19 +745,19 @@ describe("CDPSession", () => {
     Js.Promise.(
       browser^
       |> Browser.newPage
-      |> then_(page => page |> Page.target |> Target.createCDPSession)
+      |> then_(page => page->Page.target->Target.createCDPSession)
       |> then_(session =>
            session
-           |> CDPSession.send(
-                ~method_="Animation.setPlaybackRate",
-                ~params={"playbackRate": 3.1415926535},
-              )
+           ->CDPSession.send(
+               "Animation.setPlaybackRate",
+               ~params={"playbackRate": 3.1415926535},
+               (),
+             )
            |> then_(_res =>
-                session
-                |> CDPSession.send(~method_="Animation.getPlaybackRate")
+                session->CDPSession.send("Animation.getPlaybackRate", ())
               )
            |> then_(res =>
-                res##playbackRate |> expect |> toBe(3.1415926535) |> resolve
+                expect(res##playbackRate) |> toBe(3.1415926535) |> resolve
               )
          )
     )

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -358,7 +358,7 @@ describe("Page", () => {
            ->Page.addScriptTag(Page.makeTagOptions(~path=testPageJsPath, ()))
            |> then_(_elementHandle => Page.content(page))
            |> then_(content =>
-                Page.close(page)
+                page->Page.close()
                 |> then_(() =>
                      content
                      |> expect
@@ -377,7 +377,7 @@ describe("Page", () => {
            ->Page.addStyleTag(Page.makeTagOptions(~path=testPageCssPath, ()))
            |> then_(_elementHandle => Page.content(page))
            |> then_(content =>
-                Page.close(page)
+                page->Page.close()
                 |> then_(() =>
                      content
                      |> expect
@@ -390,10 +390,10 @@ describe("Page", () => {
   );
   testPromise("authenticate()", () =>
     Js.Promise.(
-      page^
-      |> Page.authenticate(
-           Js.Null.return({"username": "foo", "password": "bar"}),
-         )
+      (page^)
+      ->Page.authenticate(
+          Js.Null.return({"username": "foo", "password": "bar"}),
+        )
       |> then_(() => pass |> resolve)
     )
   );
@@ -598,7 +598,7 @@ describe("Page", () => {
     Page.coverage(page^) |> expect |> ExpectJs.toBeTruthy
   );
   afterAllPromise(() =>
-    Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
+    Js.Promise.((page^)->Page.close() |> then_(() => Browser.close(browser^)))
   );
 });
 
@@ -644,7 +644,7 @@ describe("ElementHandle", () => {
     )
   );
   afterAllPromise(() =>
-    Js.Promise.(Page.close(page^) |> then_(() => Browser.close(browser^)))
+    Js.Promise.((page^)->Page.close() |> then_(() => Browser.close(browser^)))
   );
 });
 

--- a/examples/logHtml.re
+++ b/examples/logHtml.re
@@ -10,8 +10,7 @@ let logHtml = () =>
   |> then_(browser => browser |> Browser.newPage)
   |> then_(page => {
        let options = Navigation.makeOptions(~timeout=25000., ());
-       page
-       |> Page.goto("https://google.com", ~options, ())
+       page->Page.goto("https://google.com", ~options, ())
        |> then_(res => res |> Js.Null.getExn |> Response.text);
      })
   |> then_(text => Js.log(text) |> resolve)

--- a/examples/search.re
+++ b/examples/search.re
@@ -12,8 +12,7 @@ let search = () =>
        |> then_(page => {
             let options =
               Navigation.makeOptions(~timeout=20000., ~waitUntil=`load, ());
-            page
-            |> Page.goto("https://google.com", ~options, ())
+            page->Page.goto("https://google.com", ~options, ())
             |> then_(_ => page->Page.type_("#lst-ib", "puppeteer", ()))
             |> then_(() => page->Page.click("input[type='submit']", ()))
             |> then_(() => page->Page.waitForSelector("h3 a", ()))

--- a/examples/search.re
+++ b/examples/search.re
@@ -14,17 +14,17 @@ let search = () =>
               Navigation.makeOptions(~timeout=20000., ~waitUntil=`load, ());
             page
             |> Page.goto("https://google.com", ~options, ())
-            |> then_(_ => page |> Page.type_("#lst-ib", "puppeteer", ()))
-            |> then_(() => page |> Page.click("input[type='submit']", ()))
-            |> then_(() => page |> Page.waitForSelector("h3 a", ()))
+            |> then_(_ => page->Page.type_("#lst-ib", "puppeteer", ()))
+            |> then_(() => page->Page.click("input[type='submit']", ()))
+            |> then_(() => page->Page.waitForSelector("h3 a", ()))
             |> then_(() =>
                  page
-                 |> Page.selectOneEval(
-                      "h3 a",
-                      [%raw
-                        {| function (element) { return element.textContent; } |}
-                      ],
-                    )
+                 ->Page.selectOneEval(
+                     "h3 a",
+                     [%raw
+                       {| function (element) { return element.textContent; } |}
+                     ],
+                   )
                )
             |> then_(text => Js.log2("Got:", text) |> resolve)
             |> then_(_ => Browser.close(browser))

--- a/examples/takeScreenshot.re
+++ b/examples/takeScreenshot.re
@@ -8,13 +8,12 @@ let takeScreenshot = () =>
        browser
        |> Browser.newPage
        |> then_(page =>
-            page
-            |> Page.goto("https://google.com", ())
+            page->Page.goto("https://google.com", ())
             |> then_(_ => {
                  Js.log("screenshotting");
                  let options =
                    Screenshot.makeOptions(~path="./screenshot.png", ());
-                 page |> Page.screenshot(~options, ());
+                 page->Page.screenshot(~options, ());
                })
           )
        |> then_(_ => Browser.close(browser))

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -69,45 +69,54 @@ describe("BrowserFetcher", (function () {
                 browserFetcher[0] = Puppeteer.createBrowserFetcher(Puppeteer$BsPuppeteer.makeBrowserFetcherOptions(undefined, undefined, undefined, /* () */0));
                 return /* () */0;
               }));
+        Jest.testPromise("localRevisions", undefined, (function () {
+                return browserFetcher[0].localRevisions().then((function (revisions) {
+                              revision[0] = Caml_array.caml_array_get(revisions, 0);
+                              return Promise.resolve(Jest.Expect[/* toHaveLength */13](1, Jest.Expect[/* expect */0](revisions)));
+                            }));
+              }));
         Jest.Skip[/* testPromise */2]("canDownload", undefined, (function () {
                 return browserFetcher[0].canDownload("533271").then((function ($$boolean) {
                               return Promise.resolve(Jest.Expect[/* toBe */2](true, Jest.Expect[/* expect */0]($$boolean)));
                             }));
               }));
         Jest.Skip[/* testPromise */2]("download", 30000, (function () {
-                return (function (eta) {
-                              return BrowserFetcher$BsPuppeteer.download("533271", undefined, eta);
-                            })(browserFetcher[0]).then((function (info) {
+                return browserFetcher[0].download("533271", undefined).then((function (info) {
                               return Promise.resolve(Jest.Expect[/* toBe */2]("533271", Jest.Expect[/* expect */0](info.revision)));
-                            }));
-              }));
-        Jest.testPromise("localRevisions", undefined, (function () {
-                return browserFetcher[0].localRevisions().then((function (revisions) {
-                              return Promise.resolve(Jest.Expect[/* toHaveLength */13](1, Jest.Expect[/* expect */0](revisions)));
                             }));
               }));
         Jest.test("platform", (function () {
                 return Jest.Expect[/* toEqual */12](/* linux */-184423436, Jest.Expect[/* expect */0](BrowserFetcher$BsPuppeteer.platform(browserFetcher[0])));
               }));
         Jest.Skip[/* testPromise */2]("remove", 30000, (function () {
-                return (function (eta) {
-                                  return BrowserFetcher$BsPuppeteer.download("533273", undefined, eta);
-                                })(browserFetcher[0]).then((function () {
-                                  return browserFetcher[0].remove("533273");
+                var bf = browserFetcher[0];
+                return bf.download("533273", undefined).then((function () {
+                                  return bf.remove("533273");
                                 })).then((function () {
                                 return Promise.resolve(Jest.pass);
                               })).catch((function () {
                               return Promise.resolve(Jest.fail("the revision has not been downloaded"));
                             }));
               }));
-        return Jest.test("revisionInfo", (function () {
-                      var rev = revision[0];
-                      var revisionInfo = browserFetcher[0].revisionInfo(rev);
-                      Jest.Expect[/* toBe */2](rev, Jest.Expect[/* expect */0](revisionInfo.revision));
-                      Jest.Expect[/* toContainString */11]("chromium", Jest.Expect[/* expect */0](revisionInfo.executablePath));
-                      Jest.Expect[/* toContainString */11]("chromium", Jest.Expect[/* expect */0](revisionInfo.folderPath));
-                      Jest.Expect[/* toBe */2](true, Jest.Expect[/* expect */0](revisionInfo.local));
-                      return Jest.Expect[/* toContainString */11]("https://storage.googleapis.com/", Jest.Expect[/* expect */0](revisionInfo.url));
+        Jest.test("t->revisionInfo##revision == t->revisions[0]", (function () {
+                var revisionInfo = browserFetcher[0].revisionInfo(revision[0]);
+                return Jest.Expect[/* toBe */2](revision[0], Jest.Expect[/* expect */0](revisionInfo.revision));
+              }));
+        Jest.test("t->revisionInfo##folderPath should contain chromium", (function () {
+                var revisionInfo = browserFetcher[0].revisionInfo(revision[0]);
+                return Jest.Expect[/* toContainString */11]("chromium", Jest.Expect[/* expect */0](revisionInfo.folderPath));
+              }));
+        Jest.test("t->revisionInfo##local property should be true", (function () {
+                var revisionInfo = browserFetcher[0].revisionInfo(revision[0]);
+                return Jest.Expect[/* toBe */2](true, Jest.Expect[/* expect */0](revisionInfo.local));
+              }));
+        Jest.test("t->revisionInfo##local property should be true", (function () {
+                var r = browserFetcher[0].revisionInfo(revision[0]);
+                return Jest.Expect[/* toContainString */11]("https://storage.googleapis.com/", Jest.Expect[/* expect */0](r.url));
+              }));
+        return Jest.test("revisionInfo##executablePath should contain \"chromium\"", (function () {
+                      var revisionInfo = browserFetcher[0].revisionInfo(revision[0]);
+                      return Jest.Expect[/* toContainString */11]("chromium", Jest.Expect[/* expect */0](revisionInfo.executablePath));
                     }));
       }));
 

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -19,7 +19,6 @@ var Target$BsPuppeteer = require("../src/Target.js");
 var Coverage$BsPuppeteer = require("../src/Coverage.js");
 var Viewport$BsPuppeteer = require("../src/Viewport.js");
 var Puppeteer$BsPuppeteer = require("../src/Puppeteer.js");
-var CDPSession$BsPuppeteer = require("../src/CDPSession.js");
 var BrowserFetcher$BsPuppeteer = require("../src/BrowserFetcher.js");
 
 function seconds(v) {
@@ -547,9 +546,7 @@ describe("CDPSession", (function () {
                                 return page.target().createCDPSession();
                               })).then((function (session) {
                               return session.detach().then((function () {
-                                                return (function (eta) {
-                                                            return CDPSession$BsPuppeteer.send("Animation.getPlaybackRate", undefined, eta);
-                                                          })(session);
+                                                return session.send("Animation.getPlaybackRate", undefined);
                                               })).then((function () {
                                               return Promise.resolve(Pervasives.failwith("expect with exception: Error: Protocol error (Animation.getPlaybackRate): Session closed. Most likely the page has been closed."));
                                             })).catch((function () {
@@ -561,12 +558,10 @@ describe("CDPSession", (function () {
                 return browser[0].newPage().then((function (page) {
                                 return page.target().createCDPSession();
                               })).then((function (session) {
-                              return CDPSession$BsPuppeteer.send("Animation.setPlaybackRate", {
+                              return session.send("Animation.setPlaybackRate", {
                                               playbackRate: 3.1415926535
-                                            }, session).then((function () {
-                                              return (function (eta) {
-                                                          return CDPSession$BsPuppeteer.send("Animation.getPlaybackRate", undefined, eta);
-                                                        })(session);
+                                            }).then((function () {
+                                              return session.send("Animation.getPlaybackRate", undefined);
                                             })).then((function (res) {
                                             return Promise.resolve(Jest.Expect[/* toBe */2](3.1415926535, Jest.Expect[/* expect */0](res.playbackRate)));
                                           }));

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -16,7 +16,6 @@ var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 var Page$BsPuppeteer = require("../src/Page.js");
 var Unit$BsPuppeteer = require("../src/Unit.js");
 var Target$BsPuppeteer = require("../src/Target.js");
-var Coverage$BsPuppeteer = require("../src/Coverage.js");
 var Viewport$BsPuppeteer = require("../src/Viewport.js");
 var Puppeteer$BsPuppeteer = require("../src/Puppeteer.js");
 var BrowserFetcher$BsPuppeteer = require("../src/BrowserFetcher.js");
@@ -585,9 +584,10 @@ describe("Coverage", (function () {
                 Jest.beforeAllPromise(undefined, (function () {
                         return browser[0].newPage().then((function (page) {
                                       var coverage = page.coverage;
-                                      return Coverage$BsPuppeteer.startJSCoverage({
-                                                        resetOnNavigation: true
-                                                      }, coverage).then((function () {
+                                      var options = {
+                                        resetOnNavigation: true
+                                      };
+                                      return coverage.startJSCoverage(options).then((function () {
                                                         return page.goto("file://" + testPagePath, undefined);
                                                       })).then((function () {
                                                       return coverage.stopJSCoverage();
@@ -623,9 +623,10 @@ describe("Coverage", (function () {
                 Jest.beforeAllPromise(undefined, (function () {
                         return browser[0].newPage().then((function (page) {
                                       var coverage = page.coverage;
-                                      return Coverage$BsPuppeteer.startCSSCoverage({
-                                                        resetOnNavigation: true
-                                                      }, coverage).then((function () {
+                                      var options = {
+                                        resetOnNavigation: true
+                                      };
+                                      return coverage.startCSSCoverage(options).then((function () {
                                                         return page.goto("file://" + testPagePath, undefined);
                                                       })).then((function () {
                                                       return coverage.stopCSSCoverage();

--- a/lib/js/src/BrowserFetcher.js
+++ b/lib/js/src/BrowserFetcher.js
@@ -1,11 +1,6 @@
 'use strict';
 
 var Js_mapperRt = require("bs-platform/lib/js/js_mapperRt.js");
-var Js_undefined = require("bs-platform/lib/js/js_undefined.js");
-
-function download(revision, progressCallback, t) {
-  return t.download(revision, Js_undefined.fromOption(progressCallback));
-}
 
 var jsMapperConstantArray = /* array */[
   /* tuple */[
@@ -38,7 +33,6 @@ function platform(t) {
   return platformFromJs(t.platform());
 }
 
-exports.download = download;
 exports.platformToJs = platformToJs;
 exports.platformFromJs = platformFromJs;
 exports.platform = platform;

--- a/lib/js/src/CDPSession.js
+++ b/lib/js/src/CDPSession.js
@@ -1,10 +1,1 @@
-'use strict';
-
-var Js_undefined = require("bs-platform/lib/js/js_undefined.js");
-
-function send(method__, params, t) {
-  return t.send(method__, Js_undefined.fromOption(params));
-}
-
-exports.send = send;
-/* No side effect */
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/lib/js/src/Coverage.js
+++ b/lib/js/src/Coverage.js
@@ -1,15 +1,1 @@
-'use strict';
-
-var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
-
-function startCSSCoverage(options, t) {
-  return t.startCSSCoverage(options !== undefined ? Js_primitive.valFromOption(options) : undefined);
-}
-
-function startJSCoverage(options, t) {
-  return t.startJSCoverage(options !== undefined ? Js_primitive.valFromOption(options) : undefined);
-}
-
-exports.startCSSCoverage = startCSSCoverage;
-exports.startJSCoverage = startJSCoverage;
-/* No side effect */
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/lib/js/src/Page.js
+++ b/lib/js/src/Page.js
@@ -7,7 +7,7 @@ function setBypassCSP(enabled, page) {
   return page.setBypassCSP(enabled);
 }
 
-function waitForNavigation(options, page) {
+function waitForNavigation(page, options) {
   return page.waitForNavigation(options).then((function (response) {
                 return Promise.resolve((response == null) ? undefined : Js_primitive.some(response));
               }));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "bsb -make-world",
     "clean": "bsb -clean-world",
     "lint-staged": "lint-staged",
-    "precommit": "lint-staged",
+    "precommit": "bsb -make-world && lint-staged",
     "start": "bsb -make-world -w",
     "test": "bsb -make-world && jest",
     "test:ci": "jest --bail --ci",

--- a/src/BrowserFetcher.re
+++ b/src/BrowserFetcher.re
@@ -15,13 +15,9 @@ external empty: unit => t = "%identity";
 
 [@bs.send]
 external download:
-  (t, string, Js.Undefined.t((float, float) => unit)) =>
+  (t, ~revision: string, ~progressCallback: (float, float) => unit=?, unit) =>
   Js.Promise.t(revisionInfo) =
   "";
-
-let download =
-    (~revision, ~progressCallback=?, t): Js.Promise.t(revisionInfo) =>
-  download(t, revision, progressCallback |> Js.Undefined.fromOption);
 
 [@bs.send] external localRevisions: t => Js.Promise.t(array(string)) = "";
 

--- a/src/CDPSession.re
+++ b/src/CDPSession.re
@@ -4,8 +4,5 @@ type t;
 
 [@bs.send]
 external send:
-  (t, string, Js.Undefined.t(Js.t({..}))) => Js.Promise.t(Js.t({..})) =
+  (t, string, ~params: Js.t({..})=?, unit) => Js.Promise.t(Js.t({..})) =
   "";
-
-let send = (~method_, ~params=?, t) =>
-  send(t, method_, params |> Js.Undefined.fromOption);

--- a/src/Coverage.re
+++ b/src/Coverage.re
@@ -34,17 +34,13 @@ external makeJSCoverageOptions:
 
 [@bs.send]
 external startCSSCoverage:
-  (t, ~options: cssCoverageOptions=?) => Js.Promise.t(unit) =
+  (t, ~options: cssCoverageOptions=?, unit) => Js.Promise.t(unit) =
   "";
-
-let startCSSCoverage = (~options=?, t) => startCSSCoverage(t, ~options?);
 
 [@bs.send]
 external startJSCoverage:
-  (t, ~options: jsCoverageOptions=?) => Js.Promise.t(unit) =
+  (t, ~options: jsCoverageOptions=?, unit) => Js.Promise.t(unit) =
   "";
-
-let startJSCoverage = (~options=?, t) => startJSCoverage(t, ~options?);
 
 [@bs.send] external stopCSSCoverage: t => Js.Promise.t(array(report)) = "";
 

--- a/src/ElementHandle.re
+++ b/src/ElementHandle.re
@@ -19,8 +19,9 @@ let boxModel = handle =>
   boxModel(handle)
   |> Js.Promise.(then_(handle => Js.toOption(handle) |> resolve));
 
-[@bs.send.pipe: t]
-external click: (~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
+[@bs.send]
+external click:
+  (t, ~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
   "";
 
 [@bs.send] external focus: t => Js.Promise.t(unit) = "";
@@ -29,36 +30,39 @@ external click: (~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
 
 [@bs.send] external isIntersectingViewport: t => Js.Promise.t(bool) = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external press:
-  (~key: string, ~options: Keyboard.options=?, unit) => Js.Promise.t(unit) =
+  (t, ~key: string, ~options: Keyboard.options=?, unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external screenshot:
-  (~options: Screenshot.options=?, unit) => Js.Promise.t(Node.Buffer.t) =
+  (t, ~options: Screenshot.options=?, unit) => Js.Promise.t(Node.Buffer.t) =
   "";
 
-[@bs.send.pipe: t]
-external selectOne: (~selector: string) => Js.Promise.t(Js.Null.t(t)) = "$";
+[@bs.send]
+external selectOne: (t, ~selector: string) => Js.Promise.t(Js.Null.t(t)) =
+  "$";
 
-[@bs.send.pipe: t]
-external selectAll: (~selector: string) => Js.Promise.t(array(t)) = "$$";
+[@bs.send]
+external selectAll: (t, ~selector: string) => Js.Promise.t(array(t)) = "$$";
 
-[@bs.send.pipe: t]
-external selectXPath: (~xpath: string) => Js.Promise.t(array(t)) = "$x";
+[@bs.send]
+external selectXPath: (t, ~xpath: string) => Js.Promise.t(array(t)) = "$x";
 
 [@bs.send] external tap: t => Js.Promise.t(unit) = "";
 
 [@bs.send] external toString: t => string = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external type_:
-  (~text: string, ~options: {. "delay": float}=?, unit) => Js.Promise.t(unit) =
+  (t, ~text: string, ~options: {. "delay": float}=?, unit) =>
+  Js.Promise.t(unit) =
   "type";
 
-[@bs.send.pipe: t] [@bs.splice]
-external uploadFile: (~filePaths: array(string)) => Js.Promise.t(unit) = "";
+[@bs.send] [@bs.splice]
+external uploadFile: (t, ~filePaths: array(string)) => Js.Promise.t(unit) =
+  "";
 
 [@bs.send]
 external contentFrame: t => Js.Promise.t(Js.Null.t(Types.frameBase)) = "";

--- a/src/Evaluator.re
+++ b/src/Evaluator.re
@@ -1,111 +1,126 @@
 module Impl = (T: {type t;}) => {
-  [@bs.send.pipe: T.t]
-  external evaluate: (unit => 'r) => Js.Promise.t('r) = "";
+  [@bs.send] external evaluate: (T.t, unit => 'r) => Js.Promise.t('r) = "";
 
-  [@bs.send.pipe: T.t]
-  external evaluatePromise: (unit => Js.Promise.t('r)) => Js.Promise.t('r) =
+  [@bs.send]
+  external evaluatePromise:
+    (T.t, unit => Js.Promise.t('r)) => Js.Promise.t('r) =
     "";
 
-  [@bs.send.pipe: T.t]
-  external evaluate1: ([@bs.uncurry] ('a => 'r), 'a) => Js.Promise.t('r) =
+  [@bs.send]
+  external evaluate1: (T.t, [@bs.uncurry] ('a => 'r), 'a) => Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluatePromise1:
-    ([@bs.uncurry] ('a => Js.Promise.t('r)), 'a) => Js.Promise.t('r) =
+    (T.t, [@bs.uncurry] ('a => Js.Promise.t('r)), 'a) => Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluate2:
-    ([@bs.uncurry] (('a, 'b) => 'r), 'a, 'b) => Js.Promise.t('r) =
+    (T.t, [@bs.uncurry] (('a, 'b) => 'r), 'a, 'b) => Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluatePromise2:
-    ([@bs.uncurry] (('a, 'b) => Js.Promise.t('r)), 'a, 'b) =>
+    (T.t, [@bs.uncurry] (('a, 'b) => Js.Promise.t('r)), 'a, 'b) =>
     Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluate3:
-    ([@bs.uncurry] (('a, 'b, 'c) => 'r), 'a, 'b, 'c) => Js.Promise.t('r) =
+    (T.t, [@bs.uncurry] (('a, 'b, 'c) => 'r), 'a, 'b, 'c) => Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluatePromise3:
-    ([@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t('r)), 'a, 'b, 'c) =>
+    (T.t, [@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t('r)), 'a, 'b, 'c) =>
     Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluate4:
-    ([@bs.uncurry] (('a, 'b, 'c, 'd) => 'r), 'a, 'b, 'c, 'd) =>
+    (T.t, [@bs.uncurry] (('a, 'b, 'c, 'd) => 'r), 'a, 'b, 'c, 'd) =>
     Js.Promise.t('r) =
     "evaluate";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluatePromise4:
-    ([@bs.uncurry] (('a, 'b, 'c, 'd) => Js.Promise.t('r)), 'a, 'b, 'c, 'd) =>
+    (
+      T.t,
+      [@bs.uncurry] (('a, 'b, 'c, 'd) => Js.Promise.t('r)),
+      'a,
+      'b,
+      'c,
+      'd
+    ) =>
     Js.Promise.t('r) =
     "evaluate";
 
   /** Evaluate a js expression in context. Returns the result in a promise. */
-  [@bs.send.pipe: T.t]
-  external evaluateString: string => Js.Promise.t('r) = "evaluate";
+  [@bs.send]
+  external evaluateString: (T.t, string) => Js.Promise.t('r) = "evaluate";
 
-  [@bs.send.pipe: T.t]
-  external evaluateHandle: (unit => JSHandle.t) => Js.Promise.t(JSHandle.t) =
+  [@bs.send]
+  external evaluateHandle:
+    (T.t, unit => JSHandle.t) => Js.Promise.t(JSHandle.t) =
     "";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandlePromise:
-    (unit => Js.Promise.t(JSHandle.t)) => Js.Promise.t(JSHandle.t) =
+    (T.t, unit => Js.Promise.t(JSHandle.t)) => Js.Promise.t(JSHandle.t) =
     "";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandle1:
-    ([@bs.uncurry] ('a => JSHandle.t), 'a) => Js.Promise.t(JSHandle.t) =
+    (T.t, [@bs.uncurry] ('a => JSHandle.t), 'a) => Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandlePromise1:
-    ([@bs.uncurry] ('a => Js.Promise.t(JSHandle.t)), 'a) =>
+    (T.t, [@bs.uncurry] ('a => Js.Promise.t(JSHandle.t)), 'a) =>
     Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandle2:
-    ([@bs.uncurry] (('a, 'b) => JSHandle.t), 'a, 'b) =>
+    (T.t, [@bs.uncurry] (('a, 'b) => JSHandle.t), 'a, 'b) =>
     Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandlePromise2:
-    ([@bs.uncurry] (('a, 'b) => Js.Promise.t(JSHandle.t)), 'a, 'b) =>
+    (T.t, [@bs.uncurry] (('a, 'b) => Js.Promise.t(JSHandle.t)), 'a, 'b) =>
     Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandle3:
-    ([@bs.uncurry] (('a, 'b, 'c) => JSHandle.t), 'a, 'b, 'c) =>
+    (T.t, [@bs.uncurry] (('a, 'b, 'c) => JSHandle.t), 'a, 'b, 'c) =>
     Js.Promise.t('r) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandlePromise3:
-    ([@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t(JSHandle.t)), 'a, 'b, 'c) =>
+    (
+      T.t,
+      [@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t(JSHandle.t)),
+      'a,
+      'b,
+      'c
+    ) =>
     Js.Promise.t('r) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandle4:
-    ([@bs.uncurry] (('a, 'b, 'c, 'd) => JSHandle.t), 'a, 'b, 'c, 'd) =>
+    (T.t, [@bs.uncurry] (('a, 'b, 'c, 'd) => JSHandle.t), 'a, 'b, 'c, 'd) =>
     Js.Promise.t('r) =
     "evaluateHandle";
 
-  [@bs.send.pipe: T.t]
+  [@bs.send]
   external evaluateHandlePromise4:
     (
+      T.t,
       [@bs.uncurry] (('a, 'b, 'c, 'd) => Js.Promise.t(JSHandle.t)),
       'a,
       'b,
@@ -119,8 +134,8 @@ module Impl = (T: {type t;}) => {
    * Evaluates a string of a JavaScript expression in context.
    * Returns a promise containing a JSHandle.
    */
-  [@bs.send.pipe: T.t]
-  external evaluateStringHandle: string => Js.Promise.t(JSHandle.t) =
+  [@bs.send]
+  external evaluateStringHandle: (T.t, string) => Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 };
 

--- a/src/ExecutionContext.re
+++ b/src/ExecutionContext.re
@@ -12,5 +12,5 @@ external frame: t => option(FrameBase.t) = "";
  * Iterates the JavaScript heap and finds all the objects with the given
  * prototype. Returns a handle to an array of objects with this prototype.
  */
-[@bs.send.pipe: t]
-external queryObjects: (~prototypeHandle: JSHandle.t) => JSHandle.t = "";
+[@bs.send]
+external queryObjects: (t, ~prototypeHandle: JSHandle.t) => JSHandle.t = "";

--- a/src/Frame.re
+++ b/src/Frame.re
@@ -10,5 +10,5 @@ include FrameBase;
 
 [@bs.send] [@bs.return nullable] external parentFrame: t => option(t) = "";
 
-[@bs.send.pipe: t]
-external injectFile: (~filePath: string) => Js.Promise.t(unit) = "";
+[@bs.send]
+external injectFile: (t, ~filePath: string) => Js.Promise.t(unit) = "";

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -24,19 +24,19 @@ external makeTagOptions:
   tagOptions =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOne:
-  (~selector: string) => Js.Promise.t(Js.Null.t(ElementHandle.t)) =
+  (t, ~selector: string) => Js.Promise.t(Js.Null.t(ElementHandle.t)) =
   "$";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAll:
-  (~selector: string) => Js.Promise.t(array(ElementHandle.t)) =
+  (t, ~selector: string) => Js.Promise.t(array(ElementHandle.t)) =
   "$$";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectXPath:
-  (~xpath: string) => Js.Promise.t(array(ElementHandle.t)) =
+  (t, ~xpath: string) => Js.Promise.t(array(ElementHandle.t)) =
   "$x";
 
 type selectorOptions = {
@@ -54,50 +54,50 @@ external makeSelectorOptions:
 
 /* TODO: waitForFunction */
 
-[@bs.send.pipe: t]
+[@bs.send]
 external waitForSelector:
-  (string, ~options: selectorOptions=?, unit) => Js.Promise.t(unit) =
+  (t, string, ~options: selectorOptions=?, unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external waitForXPath:
-  (~xpath: string, ~options: selectorOptions=?, unit) =>
+  (t, ~xpath: string, ~options: selectorOptions=?, unit) =>
   Js.Promise.t(ElementHandle.t) =
   "";
 
 /**
- * selectOneEval(selector, fn, page)
+ * selectOneEval(page, selector, fn)
  * Runs document.querySelector in the page and passes it as the first
  * argument to `fn`. If there's no element matching selector, the function
  * throws an error.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEval:
-  (string, [@bs.uncurry] (Dom.element => 'r)) => Js.Promise.t('r) =
+  (t, string, [@bs.uncurry] (Dom.element => 'r)) => Js.Promise.t('r) =
   "$eval";
 
 /**
- * selectOneEvalPromise(selector, fn, page)
+ * selectOneEvalPromise(page, selector, fn)
  * Runs document.querySelector in the page and passes it as the first
  * argument to `fn`. If there's no element matching selector, the function
  * throws an error. `fn` must return a promise.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEvalPromise:
-  (string, [@bs.uncurry] (Dom.element => Js.Promise.t('r))) =>
+  (t, string, [@bs.uncurry] (Dom.element => Js.Promise.t('r))) =>
   Js.Promise.t('r) =
   "$eval";
 
 /**
- * selectOneEval(selector, fn, arg1, page)
+ * selectOneEval(page, selector, fn, arg1)
  * Runs document.querySelector in the page and passes it as the first
  * argument to `fn`. Additional argument `arg1` is passed to `fn`.
  * If there's no element matching selector, the method throws an
  * error.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEval1:
-  (string, [@bs.uncurry] ((Dom.element, 'a) => 'r), 'a) => Js.Promise.t('r) =
+  (t, string, [@bs.uncurry] ((Dom.element, 'a) => 'r), 'a) => Js.Promise.t('r) =
   "$eval";
 
 /**
@@ -107,21 +107,22 @@ external selectOneEval1:
  * If there's no element matching selector, the method throws an
  * error. `fn` must return a promise.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEvalPromise1:
-  (string, [@bs.uncurry] ((Dom.element, 'a) => Js.Promise.t('r)), 'a) =>
+  (t, string, [@bs.uncurry] ((Dom.element, 'a) => Js.Promise.t('r)), 'a) =>
   Js.Promise.t('r) =
   "$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEval2:
-  (string, [@bs.uncurry] ((Dom.element, 'a, 'b) => 'r), 'a, 'b) =>
+  (t, string, [@bs.uncurry] ((Dom.element, 'a, 'b) => 'r), 'a, 'b) =>
   Js.Promise.t('r) =
   "$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEvalPromise2:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.element, 'a, 'b) => Js.Promise.t('r)),
     'a,
@@ -130,15 +131,16 @@ external selectOneEvalPromise2:
   Js.Promise.t('r) =
   "$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEval3:
-  (string, [@bs.uncurry] ((Dom.element, 'a, 'b, 'c) => 'r), 'a, 'b, 'c) =>
+  (t, string, [@bs.uncurry] ((Dom.element, 'a, 'b, 'c) => 'r), 'a, 'b, 'c) =>
   Js.Promise.t('r) =
   "$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEvalPromise3:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.element, 'a, 'b, 'c) => Js.Promise.t('r)),
     'a,
@@ -148,9 +150,10 @@ external selectOneEvalPromise3:
   Js.Promise.t('r) =
   "$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEval4:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.element, 'a, 'b, 'c, 'd) => 'r),
     'a,
@@ -161,9 +164,10 @@ external selectOneEval4:
   Js.Promise.t('r) =
   "$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectOneEvalPromise4:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.element, 'a, 'b, 'c, 'd) => Js.Promise.t('r)),
     'a,
@@ -175,49 +179,51 @@ external selectOneEvalPromise4:
   "$eval";
 
 /**
- * selectAllEval(selector, fn)
+ * selectAllEval(page, selector, fn)
  * Runs document.querySelectorAll in the page and passes it as an argument to
  * `fn`.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEval:
-  (string, [@bs.uncurry] (Dom.nodeList => 'r)) => Js.Promise.t('r) =
+  (t, string, [@bs.uncurry] (Dom.nodeList => 'r)) => Js.Promise.t('r) =
   "$$eval";
 
 /** Runs document.querySelectorAll in the page and passes it as an argument to
  * `fn`. `fn` must return a promise.
  * */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEvalPromise:
-  (string, [@bs.uncurry] (Dom.nodeList => Js.Promise.t('r))) =>
+  (t, string, [@bs.uncurry] (Dom.nodeList => Js.Promise.t('r))) =>
   Js.Promise.t('r) =
   "$$eval";
 
 /**
- * selectAllEval1(selector, fn, arg1)
+ * selectAllEval1(page, selector, fn, arg1)
  * Runs document.querySelectorAll in the page and passes the result as the
  * first argument to `fn`. It passes `arg1` as the second argument to `fn`.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEval1:
-  (string, [@bs.uncurry] ((Dom.nodeList, 'a) => 'r), 'a) => Js.Promise.t('r) =
+  (t, string, [@bs.uncurry] ((Dom.nodeList, 'a) => 'r), 'a) =>
+  Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEvalPromise1:
-  (string, [@bs.uncurry] ((Dom.nodeList, 'a) => 'r), Js.Promise.t('a)) =>
+  (t, string, [@bs.uncurry] ((Dom.nodeList, 'a) => 'r), Js.Promise.t('a)) =>
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEval2:
-  (string, [@bs.uncurry] ((Dom.nodeList, 'a, 'b) => 'r), 'a, 'b) =>
+  (t, string, [@bs.uncurry] ((Dom.nodeList, 'a, 'b) => 'r), 'a, 'b) =>
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEvalPromise2:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.nodeList, 'a, 'b) => Js.Promise.t('r)),
     'a,
@@ -226,15 +232,16 @@ external selectAllEvalPromise2:
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEval3:
-  (string, [@bs.uncurry] ((Dom.nodeList, 'a, 'b, 'c) => 'r), 'a, 'b, 'c) =>
+  (t, string, [@bs.uncurry] ((Dom.nodeList, 'a, 'b, 'c) => 'r), 'a, 'b, 'c) =>
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEvalPromise3:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.nodeList, 'a, 'b, 'c) => Js.Promise.t('r)),
     'a,
@@ -244,9 +251,10 @@ external selectAllEvalPromise3:
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEval4:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.nodeList, 'a, 'b, 'c, 'd) => 'r),
     'a,
@@ -257,9 +265,10 @@ external selectAllEval4:
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external selectAllEvalPromise4:
   (
+    t,
     string,
     [@bs.uncurry] ((Dom.nodeList, 'a, 'b, 'c, 'd) => Js.Promise.t('r)),
     'a,
@@ -270,48 +279,47 @@ external selectAllEvalPromise4:
   Js.Promise.t('r) =
   "$$eval";
 
-[@bs.send.pipe: t]
-external addScriptTag: tagOptions => Js.Promise.t(ElementHandle.t) = "";
+[@bs.send]
+external addScriptTag: (t, tagOptions) => Js.Promise.t(ElementHandle.t) = "";
 
-[@bs.send.pipe: t]
-external addStyleTag: tagOptions => Js.Promise.t(ElementHandle.t) = "";
+[@bs.send]
+external addStyleTag: (t, tagOptions) => Js.Promise.t(ElementHandle.t) = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external click:
-  (string, ~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
+  (t, string, ~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
   "";
 
 [@bs.send] external content: t => Js.Promise.t(string) = "";
 
-[@bs.send.pipe: t]
-external focus: (~selector: string) => Js.Promise.t(unit) = "";
+[@bs.send] external focus: (t, ~selector: string) => Js.Promise.t(unit) = "";
 
 /**
  * Fetches the first element matching `selector`, scrolls it into view if not
  * already visible, then hovers over the center of the element using
  * [Page.mouse]. Throws an error if no element matches `selector`.
  */
-[@bs.send.pipe: t]
-external hover: (~selector: string) => Js.Promise.t(unit) = "";
+[@bs.send]
+external hover: (t, ~selector: string) => Js.Promise.t(unit) = "";
 
 /**
  * Selects options in a `<select>` tag. Triggers a `change` and `input` event
  * once all the provided options have been selected. If there's no `<select>`
  * element matching selector it throws an error.
  */
-[@bs.send.pipe: t]
+[@bs.send]
 external select:
-  (~selector: string, ~values: array(string)) => Js.Promise.t(array(string)) =
+  (t, ~selector: string, ~values: array(string)) =>
+  Js.Promise.t(array(string)) =
   "";
 
-[@bs.send.pipe: t]
-external tap: (~selector: string) => Js.Promise.t(unit) = "";
+[@bs.send] external tap: (t, ~selector: string) => Js.Promise.t(unit) = "";
 
 type typeOptions = {. "delay": float};
 
-[@bs.send.pipe: t]
+[@bs.send]
 external type_:
-  (string, string, ~options: typeOptions=?, unit) => Js.Promise.t(unit) =
+  (t, string, string, ~options: typeOptions=?, unit) => Js.Promise.t(unit) =
   "type";
 
 [@bs.send] external url: t => string = "";

--- a/src/JSHandle.re
+++ b/src/JSHandle.re
@@ -9,8 +9,9 @@ module Impl = (T: {type t;}) => {
   [@bs.send]
   external getProperties: T.t => Js.Promise.t(JSMap.t(string, T.t)) = "";
 
-  [@bs.send.pipe: T.t]
-  external getProperty: (~propertyName: string) => Js.Promise.t(T.t) = "";
+  [@bs.send]
+  external getProperty: (T.t, ~propertyName: string) => Js.Promise.t(T.t) =
+    "";
 
   [@bs.send] external jsonValue: T.t => Js.Promise.t(Js.t({..})) = "";
 };

--- a/src/Keyboard.re
+++ b/src/Keyboard.re
@@ -9,20 +9,21 @@ type options = {
 [@bs.obj]
 external makeOptions: (~text: string=?, ~delay: float=?, unit) => options = "";
 
-[@bs.send.pipe: t]
-external down: (~key: string, ~options: options=?, unit) => Js.Promise.t(unit) =
+[@bs.send]
+external down:
+  (t, ~key: string, ~options: options=?, unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external press:
-  (~key: string, ~options: options=?, unit) => Js.Promise.t(unit) =
+  (t, ~key: string, ~options: options=?, unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t] external sendCharacter: string => Js.Promise.t(unit) = "";
+[@bs.send] external sendCharacter: (t, string) => Js.Promise.t(unit) = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external type_:
-  (~text: string, ~options: options=?, unit) => Js.Promise.t(unit) =
+  (t, ~text: string, ~options: options=?, unit) => Js.Promise.t(unit) =
   "type";
 
-[@bs.send.pipe: t] external up: string => Js.Promise.t(unit) = "";
+[@bs.send] external up: (t, string) => Js.Promise.t(unit) = "";

--- a/src/Mouse.re
+++ b/src/Mouse.re
@@ -13,22 +13,24 @@ type mousePressOptions = {
   "clickCount": int,
 };
 
-[@bs.send.pipe: t]
+[@bs.send]
 external click:
-  (~x: float, ~y: float, ~options: Click.clickOptions=?, unit) =>
+  (t, ~x: float, ~y: float, ~options: Click.clickOptions=?, unit) =>
   Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
-external down: (~options: mousePressOptions=?, unit) => Js.Promise.t(unit) =
+[@bs.send]
+external down: (t, ~options: mousePressOptions=?, unit) => Js.Promise.t(unit) =
   "";
 
 type moveOptions = {. "steps": int};
 
-[@bs.send.pipe: t]
+[@bs.send]
 external move:
-  (~x: float, ~y: float, ~options: moveOptions=?, unit) => Js.Promise.t(unit) =
+  (t, ~x: float, ~y: float, ~options: moveOptions=?, unit) =>
+  Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
-external up: (~options: mousePressOptions=?, unit) => Js.Promise.t(unit) = "";
+[@bs.send]
+external up: (t, ~options: mousePressOptions=?, unit) => Js.Promise.t(unit) =
+  "";

--- a/src/Page.re
+++ b/src/Page.re
@@ -164,21 +164,23 @@ external evaluateOnNewDocument: (unit => unit) => Js.Promise.t(unit) = "";
 [@bs.send]
 external frames: t => array(Frame.t) = "";
 
-[@bs.send.pipe: t] external setContent: string => Js.Promise.t(unit) = "";
+[@bs.send] external setContent: (t, string) => Js.Promise.t(unit) = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external goBack:
-  (~options: Navigation.options=?, unit) => Js.Promise.t(Js.null(Response.t)) =
+  (t, ~options: Navigation.options=?, unit) =>
+  Js.Promise.t(Js.null(Response.t)) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external goForward:
-  (~options: Navigation.options=?, unit) => Js.Promise.t(Js.null(Response.t)) =
+  (t, ~options: Navigation.options=?, unit) =>
+  Js.Promise.t(Js.null(Response.t)) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external goto:
-  (string, ~options: Navigation.options=?, unit) =>
+  (t, string, ~options: Navigation.options=?, unit) =>
   Js.Promise.t(Js.null(Response.t)) =
   "";
 
@@ -203,66 +205,64 @@ external metrics: t => Js.Promise.t(Metrics.t) = "";
 [@bs.get]
 external mouse: t => Mouse.t = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external screenshot:
-  (~options: Screenshot.options=?, unit) => Js.Promise.t(Node.Buffer.t) =
+  (t, ~options: Screenshot.options=?, unit) => Js.Promise.t(Node.Buffer.t) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external setExtraHTTPHeaders:
-  (~headers: Js.Dict.t(string), unit) => Js.Promise.t(unit) =
+  (t, ~headers: Js.Dict.t(string), unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t] [@bs.splice]
-external deleteCookie: array(cookie) => Js.Promise.t(unit) = "";
+[@bs.send] [@bs.splice]
+external deleteCookie: (t, array(cookie)) => Js.Promise.t(unit) = "";
 
-[@bs.send.pipe: t] [@bs.splice]
-external cookies: array(string) => Js.Promise.t(array(cookie)) = "";
+[@bs.send] [@bs.splice]
+external cookies: (t, array(string)) => Js.Promise.t(array(cookie)) = "";
 
-[@bs.send.pipe: t] [@bs.splice]
-external setCookie: array(cookie) => Js.Promise.t(unit) = "";
+[@bs.send] [@bs.splice]
+external setCookie: (t, array(cookie)) => Js.Promise.t(unit) = "";
 
-[@bs.send.pipe: t]
-external emulate: emulateOptions => Js.Promise.t(unit) = "";
+[@bs.send] external emulate: (t, emulateOptions) => Js.Promise.t(unit) = "";
 
 [@bs.send] [@bs.return nullable]
 external viewport: t => option(viewport) = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external emulateMedia:
-  ([@bs.string] [ | `screen | `print]) => Js.Promise.t(unit) =
+  (t, [@bs.string] [ | `screen | `print]) => Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external emulateMediaDisable:
-  ([@bs.as {json|null|json}] _) => Js.Promise.t(unit) =
+  (t, [@bs.as {json|null|json}] _) => Js.Promise.t(unit) =
   "emulateMedia";
 
-[@bs.send.pipe: t]
-external pdf: pdfOptions => Js.Promise.t(Node.Buffer.t) = "";
+[@bs.send] external pdf: (t, pdfOptions) => Js.Promise.t(Node.Buffer.t) = "";
 
 /* TODO:
       external on
       external once
    */
 /** Iterates the JS heap finding all the objects with the given prototype. */
-[@bs.send.pipe: t]
+[@bs.send]
 external queryObjects:
-  (~prototypeHandle: JSHandle.t) => Js.Promise.t(JSHandle.t) =
+  (t, ~prototypeHandle: JSHandle.t) => Js.Promise.t(JSHandle.t) =
   "";
 
 /** Reload the current page. */
-[@bs.send.pipe: t]
+[@bs.send]
 external reload:
-  (~options: Navigation.options=?, unit) => Js.Promise.t(Response.t) =
+  (t, ~options: Navigation.options=?, unit) => Js.Promise.t(Response.t) =
   "";
 
 /**
  * Toggles ignoring cache for each request based on the enabled state.
  * Caching is enabled by default.
  */
-[@bs.send.pipe: t]
-external setCacheEnabled: (~enabled: bool) => Js.Promise.t(unit) = "";
+[@bs.send]
+external setCacheEnabled: (t, ~enabled: bool) => Js.Promise.t(unit) = "";
 
 /**
  * Change the default maximum navigation time of 30 seconds for the following:
@@ -272,23 +272,24 @@ external setCacheEnabled: (~enabled: bool) => Js.Promise.t(unit) = "";
  * - `Page.reload`
  * - `Page.waitForNavigation`
  */
-[@bs.send.pipe: t]
-external setDefaultNavigationTimeout: (~timeout: float) => unit = "";
+[@bs.send]
+external setDefaultNavigationTimeout: (t, ~timeout: float) => unit = "";
 
 /** Set whether to enable JavaScript on the page. */
-[@bs.send.pipe: t]
-external setJavaScriptEnabled: (~enabled: bool) => Js.Promise.t(unit) = "";
+[@bs.send]
+external setJavaScriptEnabled: (t, ~enabled: bool) => Js.Promise.t(unit) = "";
 
 /** Set whether to enable offline mode for the page. */
-[@bs.send.pipe: t]
-external setOfflineMode: (~enabled: bool) => Js.Promise.t(unit) = "";
+[@bs.send]
+external setOfflineMode: (t, ~enabled: bool) => Js.Promise.t(unit) = "";
 
 /** Set whether to enable request interception for the page. */
-[@bs.send.pipe: t]
-external setRequestInterception: (~enabled: bool) => Js.Promise.t(unit) = "";
+[@bs.send]
+external setRequestInterception: (t, ~enabled: bool) => Js.Promise.t(unit) =
+  "";
 
-[@bs.send.pipe: t]
-external setUserAgent: (~userAgent: string) => Js.Promise.t(unit) = "";
+[@bs.send]
+external setUserAgent: (t, ~userAgent: string) => Js.Promise.t(unit) = "";
 
 /** Toggle bypassing page's Content-Security-Policy. */
 [@bs.send]
@@ -296,8 +297,8 @@ external setBypassCSP: (t, ~enabled: bool) => Js.Promise.t(unit) = "";
 
 let setBypassCSP = (~enabled, page) => setBypassCSP(page, ~enabled);
 
-[@bs.send.pipe: t]
-external setViewport: (~viewport: viewport) => Js.Promise.t(unit) = "";
+[@bs.send]
+external setViewport: (t, ~viewport: viewport) => Js.Promise.t(unit) = "";
 
 [@bs.send] external target: t => Types.target = "";
 
@@ -307,13 +308,13 @@ external setViewport: (~viewport: viewport) => Js.Promise.t(unit) = "";
 
 [@bs.get] external tracing: t => Tracing.t = "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external waitForNavigation:
-  (~options: Navigation.options) => Js.Promise.t(Js.nullable(Response.t)) =
+  (t, ~options: Navigation.options) => Js.Promise.t(Js.nullable(Response.t)) =
   "";
 
-let waitForNavigation = (~options, page) =>
-  waitForNavigation(~options, page)
+let waitForNavigation = (page, ~options) =>
+  waitForNavigation(page, ~options)
   |> Js.Promise.(then_(response => response |> Js.toOption |> resolve));
 
 module WaitForRequest = {

--- a/src/Page.re
+++ b/src/Page.re
@@ -134,8 +134,9 @@ external makePDFOptions:
   pdfOptions =
   "";
 
-[@bs.send.pipe: t]
-external authenticate: Js.Null.t(authOptions) => Js.Promise.t(unit) = "";
+[@bs.send]
+external authenticate: (t, Js.Null.t(authOptions)) => Js.Promise.t(unit) =
+  "";
 
 /** Bring the page to front (activate the tab). */
 [@bs.send]
@@ -149,14 +150,15 @@ type closeOptions = {. "runBeforeUnload": Js.nullable(bool)};
 external makeCloseOptions: (~runBeforeUnload: bool=?, unit) => closeOptions =
   "";
 
-[@bs.send.pipe: t]
-external close: (~options: closeOptions=?) => Js.Promise.t(unit) = "";
+[@bs.send]
+external close: (t, ~options: closeOptions=?, unit) => Js.Promise.t(unit) =
+  "";
 
 [@bs.get] external coverage: t => Coverage.t = "";
 
 /* TODO: versions handling args */
-[@bs.send.pipe: t]
-external evaluateOnNewDocument: (unit => unit) => Js.Promise.t(unit) = "";
+[@bs.send]
+external evaluateOnNewDocument: (t, unit => unit) => Js.Promise.t(unit) = "";
 
 /* TODO: exposeFunction */
 

--- a/src/Request.re
+++ b/src/Request.re
@@ -45,9 +45,10 @@ external makeOverrides:
   overrides =
   "";
 
-[@bs.send.pipe: t]
+[@bs.send]
 external abort:
   (
+    t,
     ~errorCode: [@bs.string] [
                   | `aborted
                   | `accessdenied
@@ -70,8 +71,9 @@ external abort:
   Js.Promise.t(unit) =
   "";
 
-[@bs.send.pipe: t]
-external continue: (~overrides: overrides=?, unit) => Js.Promise.t(unit) = "";
+[@bs.send]
+external continue: (t, ~overrides: overrides=?, unit) => Js.Promise.t(unit) =
+  "";
 
 [@bs.send] [@bs.return nullable]
 external failure: t => option({. "errorText": string}) = "";
@@ -142,8 +144,7 @@ external makeRespondOptions:
   respondOptions =
   "";
 
-[@bs.send.pipe: t]
-external respond: respondOptions => Js.Promise.t(unit) = "";
+[@bs.send] external respond: (t, respondOptions) => Js.Promise.t(unit) = "";
 
 [@bs.send] [@bs.return nullable]
 external response: t => option(Types.response) = "";

--- a/src/Touchscreen.re
+++ b/src/Touchscreen.re
@@ -1,4 +1,3 @@
 type t;
 
-[@bs.send.pipe: t]
-external tap: (~x: float, ~y: float) => Js.Promise.t(unit) = "";
+[@bs.send] external tap: (t, ~x: float, ~y: float) => Js.Promise.t(unit) = "";

--- a/src/Tracing.re
+++ b/src/Tracing.re
@@ -13,7 +13,8 @@ external makeTracingOptions:
   tracingOptions =
   "";
 
-[@bs.send.pipe: t]
-external start: (~options: tracingOptions, unit) => Js.Promise.t(unit) = "";
+[@bs.send]
+external start: (t, ~options: tracingOptions, unit) => Js.Promise.t(unit) =
+  "";
 
 [@bs.send] external stop: t => Js.Promise.t(Node.Buffer.t) = "";


### PR DESCRIPTION
Convert all `bs.send.pipe` externals to `bs.send` for use with fast pipe (`->` or `|.`). For bindings with multiple arguments the object is moved from the last to the first argument.

This is a breaking change, but one that I think is worthwhile. It eliminates a extra JS function calls in the generated JavaScript. Switching `|>` to `->` is straight forward and the compiler will tell exactly where it needs to be changed.

In a few instances it was necessary to add a final `unit` argument after one or more optional arguments. Again, the compiler will complain about this and it's a straightforward fix.

Fixes #36.