### PR TITLE
Add BrowserContext permission overrides

### DIFF
--- a/lib/js/src/BrowserContext.js
+++ b/lib/js/src/BrowserContext.js
@@ -1,1 +1,89 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */
+'use strict';
+
+var $$Array = require("bs-platform/lib/js/array.js");
+var Js_mapperRt = require("bs-platform/lib/js/js_mapperRt.js");
+
+var jsMapperConstantArray = /* array */[
+  /* tuple */[
+    -970104761,
+    "accesibilityEvents"
+  ],
+  /* tuple */[
+    -956395323,
+    "gyroscope"
+  ],
+  /* tuple */[
+    -933476895,
+    "midi"
+  ],
+  /* tuple */[
+    -899608102,
+    "push"
+  ],
+  /* tuple */[
+    -617037192,
+    "ambient-light-sensor"
+  ],
+  /* tuple */[
+    -533823412,
+    "clipboard-read"
+  ],
+  /* tuple */[
+    151985871,
+    "accelerometer"
+  ],
+  /* tuple */[
+    185694564,
+    "payment-handler"
+  ],
+  /* tuple */[
+    315713478,
+    "geolocation"
+  ],
+  /* tuple */[
+    451566879,
+    "midi-sysex"
+  ],
+  /* tuple */[
+    544868713,
+    "background-sync"
+  ],
+  /* tuple */[
+    612348388,
+    "magnetometer"
+  ],
+  /* tuple */[
+    727379946,
+    "microphone"
+  ],
+  /* tuple */[
+    764221224,
+    "notifications"
+  ],
+  /* tuple */[
+    840994601,
+    "clipboard-write"
+  ],
+  /* tuple */[
+    931940005,
+    "camera"
+  ]
+];
+
+function permissionToJs(param) {
+  return Js_mapperRt.binarySearch(16, param, jsMapperConstantArray);
+}
+
+function permissionFromJs(param) {
+  return Js_mapperRt.revSearch(16, jsMapperConstantArray, param);
+}
+
+function overridePermissions(ctx, origin, permissions) {
+  var permissions$1 = $$Array.map(permissionToJs, permissions);
+  return ctx.overridePermissionsUnsafe(origin, permissions$1);
+}
+
+exports.permissionToJs = permissionToJs;
+exports.permissionFromJs = permissionFromJs;
+exports.overridePermissions = overridePermissions;
+/* No side effect */

--- a/src/Browser.re
+++ b/src/Browser.re
@@ -10,6 +10,8 @@ external empty: unit => t = "%identity";
 external createIncognitoBrowserContext: t => Js.Promise.t(BrowserContext.t) =
   "";
 
+[@bs.send] external defaultBrowserContext: t => BrowserContext.t = "";
+
 [@bs.send] external disconnect: t => unit = "";
 
 [@bs.send] external newPage: t => Js.Promise.t(Page.t) = "";

--- a/src/BrowserContext.re
+++ b/src/BrowserContext.re
@@ -1,12 +1,47 @@
 type t;
 
+[@bs.deriving jsConverter]
+type permission = [
+  | `geolocation
+  | `midi
+  | `notifications
+  | `push
+  | `camera
+  | `microphone
+  | [@bs.as "background-sync"] `backgroundSync
+  | [@bs.as "ambient-light-sensor"] `ambientLightSensor
+  | `accelerometer
+  | `gyroscope
+  | `magnetometer
+  | [@bs.as "accesibilityEvents"] `accessibilityEvents
+  | [@bs.as "clipboard-read"] `clipboardRead
+  | [@bs.as "clipboard-write"] `clipboardWrite
+  | [@bs.as "payment-handler"] `paymentHandler
+  | [@bs.as "midi-sysex"] `midiSysex
+];
+
 [@bs.send] external browser: t => Types.browser = "";
+
+/** Clear permission overrides for the browser context. */
+[@bs.send]
+external clearPermissionOverrides: t => Js.Promise.t(unit) = "";
 
 [@bs.send] external close: t => Js.Promise.t(unit) = "";
 
 [@bs.send] external isIncognito: t => bool = "";
 
 [@bs.send] external newPage: t => Js.Promise.t(Page.t) = "";
+
+[@bs.send]
+external overridePermissionsUnsafe:
+  (t, ~origin: string, ~permissions: array(string)) => Js.Promise.t(unit) =
+  "";
+
+/** Grant permissions for an origin. All other permissions will be denied. */
+let overridePermissions = (ctx, ~origin, ~permissions) => {
+  let permissions = Array.map(permissionToJs, permissions);
+  overridePermissionsUnsafe(ctx, ~origin, ~permissions);
+};
 
 [@bs.send] external pages: t => Js.Promise.t(array(Page.t)) = "";
 


### PR DESCRIPTION
Add BrowserContext.permission poly-variant with string enum converters.

Adds the following functions:
- Browser.defaultBrowserContext
- BrowserContext.overridePermissions
- BrowserContext.overridePermissionsUnsafe

The unsafe version takes an array of strings instead of the permission type.

Fixes #78.