### PR TITLE
Expose multiple execution contexts in Frame

### DIFF
--- a/src/ExecutionContext.re
+++ b/src/ExecutionContext.re
@@ -8,6 +8,14 @@ include Evaluator.Impl({
 [@bs.send] [@bs.return nullable]
 external frame: t => option(FrameBase.t) = "";
 
+/** True if the execution context is the main one for a frame. */
+[@bs.send]
+external isDefault: t => bool = "";
+
+/** Name of the execution context. */
+[@bs.send]
+external name: t => string = "";
+
 /**
  * Iterates the JavaScript heap and finds all the objects with the given
  * prototype. Returns a handle to an array of objects with this prototype.

--- a/src/Frame.re
+++ b/src/Frame.re
@@ -2,7 +2,9 @@ include FrameBase;
 
 [@bs.send] external childFrames: t => array(t) = "";
 
-[@bs.send] external executionContext: t => ExecutionContext.t = "";
+/** Promise of the frame's default execution context. */
+[@bs.send]
+external executionContext: t => Js.Promise.t(ExecutionContext.t) = "";
 
 [@bs.send] external isDetached: t => bool = "";
 

--- a/src/Frame.re
+++ b/src/Frame.re
@@ -6,6 +6,10 @@ include FrameBase;
 [@bs.send]
 external executionContext: t => Js.Promise.t(ExecutionContext.t) = "";
 
+/** Array of execution contexts associated with the frame. */
+[@bs.send]
+external executionContexts: t => array(ExecutionContext.t) = "";
+
 [@bs.send] external isDetached: t => bool = "";
 
 [@bs.send] external name: t => string = "";


### PR DESCRIPTION
Expose multiple `ExecutionContexts` from a `Frame` (adding the `executionContexts` function). Add the `isDefault` and `name` functions to the `ExecutionContext` module.

Also fixed a bug where `Frame.executionContext` was was not returning a promise.

Fixes #84.