### PR TITLE
Use variant for ignoreDefaultArgs launch option

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,5 +2,3 @@
 "{src,examples,__tests__}/**/*.{re,rei}":
   - "bsrefmt --in-place"
   - "git add"
-"lib/js/**/*.js":
-  - "jest --bail --findRelatedTests"

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -56,6 +56,21 @@ describe("Puppeteer", () => {
     let args = defaultArgs(~options, ());
     args |> Array.length |> expect |> toBeGreaterThan(0);
   });
+
+  testPromise("should launch with ignoreDefaultArgs array of args", () => {
+    let ignoreDefaultArgs = IgnoreDefaultArgs.Args([|"--mute-audio"|]);
+    let options = makeLaunchOptions(~ignoreDefaultArgs, ());
+    Js.Promise.(
+      launch(~options, ())
+      |> then_(b =>
+           Js.Promise.all2((
+             Browser.close(b),
+             expect(b) |> ExpectJs.toBeTruthy |> resolve,
+           ))
+         )
+      |> Js.Promise.then_(((_, res)) => resolve(res))
+    );
+  });
 });
 
 describe("BrowserFetcher", () => {

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -59,7 +59,8 @@ describe("Puppeteer", () => {
 
   testPromise("should launch with ignoreDefaultArgs array of args", () => {
     let ignoreDefaultArgs = IgnoreDefaultArgs.Args([|"--mute-audio"|]);
-    let options = makeLaunchOptions(~ignoreDefaultArgs, ());
+    let args = [|"--no-sandbox"|];
+    let options = makeLaunchOptions(~args, ~ignoreDefaultArgs, ());
     Js.Promise.(
       launch(~options, ())
       |> then_(b =>

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -59,7 +59,8 @@ describe("Puppeteer", (function () {
               }));
         return Jest.testPromise("should launch with ignoreDefaultArgs array of args", undefined, (function () {
                       var ignoreDefaultArgs = /* Args */Block.__(1, [/* array */["--mute-audio"]]);
-                      var options = Puppeteer$BsPuppeteer.makeLaunchOptions(undefined, undefined, undefined, undefined, undefined, undefined, ignoreDefaultArgs, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, /* () */0);
+                      var args = /* array */["--no-sandbox"];
+                      var options = Puppeteer$BsPuppeteer.makeLaunchOptions(undefined, undefined, undefined, undefined, undefined, args, ignoreDefaultArgs, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, /* () */0);
                       return Puppeteer.launch(options).then((function (b) {
                                       return Promise.all(/* tuple */[
                                                   b.close(),

--- a/lib/js/__tests__/puppeteer_test.js
+++ b/lib/js/__tests__/puppeteer_test.js
@@ -3,6 +3,7 @@
 var Fs = require("fs");
 var Jest = require("@glennsl/bs-jest/lib/js/src/jest.js");
 var Path = require("path");
+var Block = require("bs-platform/lib/js/block.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var Js_exn = require("bs-platform/lib/js/js_exn.js");
 var Js_dict = require("bs-platform/lib/js/js_dict.js");
@@ -42,9 +43,7 @@ var testPageCssPath = Path.resolve(fixturesPath, "./testPage.css");
 
 var testPageContent = Fs.readFileSync(testPagePath, "utf8");
 
-var noSandbox = {
-  args: /* array */["--no-sandbox"]
-};
+var noSandbox = Puppeteer$BsPuppeteer.makeLaunchOptions(undefined, undefined, undefined, undefined, undefined, /* array */["--no-sandbox"], undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, /* () */0);
 
 describe("Puppeteer", (function () {
         Jest.test("executablePath", (function () {
@@ -53,10 +52,22 @@ describe("Puppeteer", (function () {
         Jest.test("defaultArgs()", (function () {
                 return Jest.Expect[/* toBeGreaterThan */5](0, Jest.Expect[/* expect */0](Puppeteer.defaultArgs(undefined).length));
               }));
-        return Jest.test("calling defaultArgs with options", (function () {
-                      var options = Puppeteer$BsPuppeteer.DefaultArgsOptions[/* make */0](true, undefined, undefined, undefined, /* () */0);
-                      var args = Puppeteer.defaultArgs(options);
-                      return Jest.Expect[/* toBeGreaterThan */5](0, Jest.Expect[/* expect */0](args.length));
+        Jest.test("calling defaultArgs with options", (function () {
+                var options = Puppeteer$BsPuppeteer.DefaultArgsOptions[/* make */0](true, undefined, undefined, undefined, /* () */0);
+                var args = Puppeteer.defaultArgs(options);
+                return Jest.Expect[/* toBeGreaterThan */5](0, Jest.Expect[/* expect */0](args.length));
+              }));
+        return Jest.testPromise("should launch with ignoreDefaultArgs array of args", undefined, (function () {
+                      var ignoreDefaultArgs = /* Args */Block.__(1, [/* array */["--mute-audio"]]);
+                      var options = Puppeteer$BsPuppeteer.makeLaunchOptions(undefined, undefined, undefined, undefined, undefined, undefined, ignoreDefaultArgs, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, /* () */0);
+                      return Puppeteer.launch(options).then((function (b) {
+                                      return Promise.all(/* tuple */[
+                                                  b.close(),
+                                                  Promise.resolve(Jest.ExpectJs[/* toBeTruthy */28](Jest.Expect[/* expect */0](b)))
+                                                ]);
+                                    })).then((function (param) {
+                                    return Promise.resolve(param[1]);
+                                  }));
                     }));
       }));
 

--- a/lib/js/src/Launcher.js
+++ b/lib/js/src/Launcher.js
@@ -1,59 +1,8 @@
 'use strict';
 
-var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
+var Puppeteer$BsPuppeteer = require("./Puppeteer.js");
 
-function makeLaunchOptions(prim, prim$1, prim$2, prim$3, prim$4, prim$5, prim$6, prim$7, prim$8, prim$9, prim$10, prim$11, prim$12, prim$13, prim$14, prim$15, _) {
-  var tmp = { };
-  if (prim !== undefined) {
-    tmp.ignoreHTTPSErrors = Js_primitive.valFromOption(prim);
-  }
-  if (prim$1 !== undefined) {
-    tmp.headless = Js_primitive.valFromOption(prim$1);
-  }
-  if (prim$2 !== undefined) {
-    tmp.executablePath = Js_primitive.valFromOption(prim$2);
-  }
-  if (prim$3 !== undefined) {
-    tmp.slowMo = Js_primitive.valFromOption(prim$3);
-  }
-  if (prim$4 !== undefined) {
-    tmp.defaultViewport = Js_primitive.valFromOption(prim$4);
-  }
-  if (prim$5 !== undefined) {
-    tmp.args = Js_primitive.valFromOption(prim$5);
-  }
-  if (prim$6 !== undefined) {
-    tmp.ignoreDefaultArgs = Js_primitive.valFromOption(prim$6);
-  }
-  if (prim$7 !== undefined) {
-    tmp.handleSIGINT = Js_primitive.valFromOption(prim$7);
-  }
-  if (prim$8 !== undefined) {
-    tmp.handleSIGTERM = Js_primitive.valFromOption(prim$8);
-  }
-  if (prim$9 !== undefined) {
-    tmp.handleSIGHUP = Js_primitive.valFromOption(prim$9);
-  }
-  if (prim$10 !== undefined) {
-    tmp.timeout = Js_primitive.valFromOption(prim$10);
-  }
-  if (prim$11 !== undefined) {
-    tmp.dumpio = Js_primitive.valFromOption(prim$11);
-  }
-  if (prim$12 !== undefined) {
-    tmp.userDataDir = Js_primitive.valFromOption(prim$12);
-  }
-  if (prim$13 !== undefined) {
-    tmp.env = Js_primitive.valFromOption(prim$13);
-  }
-  if (prim$14 !== undefined) {
-    tmp.devtools = Js_primitive.valFromOption(prim$14);
-  }
-  if (prim$15 !== undefined) {
-    tmp.pipe = Js_primitive.valFromOption(prim$15);
-  }
-  return tmp;
-}
+var makeLaunchOptions = Puppeteer$BsPuppeteer.makeLaunchOptions;
 
 exports.makeLaunchOptions = makeLaunchOptions;
 /* No side effect */

--- a/lib/js/src/Puppeteer.js
+++ b/lib/js/src/Puppeteer.js
@@ -1,8 +1,76 @@
 'use strict';
 
 var Js_option = require("bs-platform/lib/js/js_option.js");
+var Belt_Option = require("bs-platform/lib/js/belt_Option.js");
 var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 var BrowserFetcher$BsPuppeteer = require("./BrowserFetcher.js");
+
+function encode(param) {
+  return param[0];
+}
+
+function encodeOpt(__x) {
+  return Belt_Option.map(__x, encode);
+}
+
+var IgnoreDefaultArgs = /* module */[
+  /* encode */encode,
+  /* encodeOpt */encodeOpt
+];
+
+function makeLaunchOptions(ignoreHTTPSErrors, headless, executablePath, slowMo, defaultViewport, args, ignoreDefaultArgs, handleSIGINT, handleSIGTERM, handleSIGHUP, timeout, dumpio, userDataDir, env, devtools, pipe, _) {
+  var tmp = { };
+  if (ignoreHTTPSErrors !== undefined) {
+    tmp.ignoreHTTPSErrors = Js_primitive.valFromOption(ignoreHTTPSErrors);
+  }
+  if (headless !== undefined) {
+    tmp.headless = Js_primitive.valFromOption(headless);
+  }
+  if (executablePath !== undefined) {
+    tmp.executablePath = Js_primitive.valFromOption(executablePath);
+  }
+  if (slowMo !== undefined) {
+    tmp.slowMo = Js_primitive.valFromOption(slowMo);
+  }
+  if (defaultViewport !== undefined) {
+    tmp.defaultViewport = Js_primitive.valFromOption(defaultViewport);
+  }
+  if (args !== undefined) {
+    tmp.args = Js_primitive.valFromOption(args);
+  }
+  var tmp$1 = Belt_Option.map(ignoreDefaultArgs, encode);
+  if (tmp$1 !== undefined) {
+    tmp.ignoreDefaultArgs = Js_primitive.valFromOption(tmp$1);
+  }
+  if (handleSIGINT !== undefined) {
+    tmp.handleSIGINT = Js_primitive.valFromOption(handleSIGINT);
+  }
+  if (handleSIGTERM !== undefined) {
+    tmp.handleSIGTERM = Js_primitive.valFromOption(handleSIGTERM);
+  }
+  if (handleSIGHUP !== undefined) {
+    tmp.handleSIGHUP = Js_primitive.valFromOption(handleSIGHUP);
+  }
+  if (timeout !== undefined) {
+    tmp.timeout = Js_primitive.valFromOption(timeout);
+  }
+  if (dumpio !== undefined) {
+    tmp.dumpio = Js_primitive.valFromOption(dumpio);
+  }
+  if (userDataDir !== undefined) {
+    tmp.userDataDir = Js_primitive.valFromOption(userDataDir);
+  }
+  if (env !== undefined) {
+    tmp.env = Js_primitive.valFromOption(env);
+  }
+  if (devtools !== undefined) {
+    tmp.devtools = Js_primitive.valFromOption(devtools);
+  }
+  if (pipe !== undefined) {
+    tmp.pipe = Js_primitive.valFromOption(pipe);
+  }
+  return tmp;
+}
 
 function make(prim, prim$1, prim$2, prim$3, _) {
   var tmp = { };
@@ -38,6 +106,8 @@ function makeBrowserFetcherOptions(host, path, platform, _) {
   return tmp;
 }
 
+exports.IgnoreDefaultArgs = IgnoreDefaultArgs;
+exports.makeLaunchOptions = makeLaunchOptions;
 exports.DefaultArgsOptions = DefaultArgsOptions;
 exports.makeBrowserFetcherOptions = makeBrowserFetcherOptions;
 /* No side effect */

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "bsb -make-world",
     "clean": "bsb -clean-world",
     "lint-staged": "lint-staged",
-    "precommit": "bsb -make-world && lint-staged",
+    "precommit": "lint-staged && bsb -clean-world -make-world && jest",
     "start": "bsb -make-world -w",
     "test": "bsb -make-world && jest",
     "test:ci": "jest --bail --ci",

--- a/src/Puppeteer.re
+++ b/src/Puppeteer.re
@@ -29,6 +29,20 @@ external connect:
 [@bs.val] [@bs.module "puppeteer"]
 external executablePath: unit => string = "";
 
+module IgnoreDefaultArgs = {
+  type t;
+  type arg =
+    | Bool(bool)
+    | Args(array(string));
+
+  let encode: arg => t =
+    fun
+    | Bool(b) => Obj.magic(b)
+    | Args(args) => Obj.magic(args);
+
+  let encodeOpt = Belt.Option.map(_, encode);
+};
+
 type launchOptions = {
   .
   "ignoreHTTPSErrors": Js.undefined(bool),
@@ -37,7 +51,7 @@ type launchOptions = {
   "slowMo": Js.undefined(float),
   "defaultViewport": Js.nullable(Viewport.t),
   "args": Js.undefined(array(string)),
-  "ignoreDefaultArgs": Js.undefined(bool),
+  "ignoreDefaultArgs": Js.undefined(IgnoreDefaultArgs.t),
   "handleSIGINT": Js.undefined(bool),
   "handleSIGTERM": Js.undefined(bool),
   "handleSIGHUP": Js.undefined(bool),
@@ -58,7 +72,7 @@ external makeLaunchOptions:
     ~slowMo: float=?,
     ~defaultViewport: Viewport.t=?,
     ~args: array(string)=?,
-    ~ignoreDefaultArgs: bool=?,
+    ~ignoreDefaultArgs: IgnoreDefaultArgs.t=?,
     ~handleSIGINT: bool=?,
     ~handleSIGTERM: bool=?,
     ~handleSIGHUP: bool=?,
@@ -72,6 +86,46 @@ external makeLaunchOptions:
   ) =>
   launchOptions =
   "";
+
+let makeLaunchOptions =
+    (
+      ~ignoreHTTPSErrors=?,
+      ~headless=?,
+      ~executablePath=?,
+      ~slowMo=?,
+      ~defaultViewport=?,
+      ~args=?,
+      ~ignoreDefaultArgs=?,
+      ~handleSIGINT=?,
+      ~handleSIGTERM=?,
+      ~handleSIGHUP=?,
+      ~timeout=?,
+      ~dumpio=?,
+      ~userDataDir=?,
+      ~env=?,
+      ~devtools=?,
+      ~pipe=?,
+      (),
+    ) =>
+  makeLaunchOptions(
+    ~ignoreHTTPSErrors?,
+    ~headless?,
+    ~executablePath?,
+    ~slowMo?,
+    ~defaultViewport?,
+    ~args?,
+    ~ignoreDefaultArgs=?IgnoreDefaultArgs.encodeOpt(ignoreDefaultArgs),
+    ~handleSIGINT?,
+    ~handleSIGTERM?,
+    ~handleSIGHUP?,
+    ~timeout?,
+    ~dumpio?,
+    ~userDataDir?,
+    ~env?,
+    ~devtools?,
+    ~pipe?,
+    (),
+  );
 
 /** Launch a browser instance. */
 [@bs.val] [@bs.module "puppeteer"]


### PR DESCRIPTION
Enable passing either a bool or array(string) as ignoreDefaultArgs. This is a breaking change but we can just provide instructions for any existing users of this option to wrap the value in `IgnoreDefaultArgs.Bool`.

Fixes #85.