### PR TITLE
Use bs-webapi in tests and examples

### DIFF
--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -10,10 +10,6 @@ let seconds = v => v * 1000;
 
 [@bs.val] external fetch: string => Js.Promise.t(Response.t) = "";
 
-let getLengthOfElementsJs = [%raw
-  {| function (elements) { return elements.length; } |}
-];
-
 let fixturesPath =
   Node.Path.resolve(
     [%bs.node __dirname] |> Js.Option.getWithDefault(""),
@@ -248,8 +244,8 @@ describe("Page", () => {
 
   testPromise("$$eval()", () =>
     Js.Promise.(
-      (page^)->Page.selectAllEval("html,body", getLengthOfElementsJs)
-      |> then_(length => length |> expect |> toBe(2.0) |> resolve)
+      (page^)->Page.selectAllEval("html,body", D.NodeList.length)
+      |> then_(length => expect(length) |> toBe(2) |> resolve)
     )
   );
 

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -10,10 +10,6 @@ let seconds = v => v * 1000;
 
 [@bs.val] external fetch: string => Js.Promise.t(Response.t) = "";
 
-let getElementValueJs: Dom.element => string = [%raw
-  {| function (element) { return element.value; } |}
-];
-
 let getLengthOfElementsJs = [%raw
   {| function (elements) { return elements.length; } |}
 ];
@@ -384,20 +380,19 @@ describe("Page", () => {
     )
   );
 
-  testPromise("type()", () =>
+  testPromise("type()", () => {
+    let getVal = el => el->D.Element.unsafeAsHtmlElement->D.HtmlElement.value;
     Js.Promise.(
       browser^
       |> Browser.newPage
       |> then_(page =>
            page->Page.setContent(testPageContent)
            |> then_(() => page->Page.type_("#input", "hello world", ()))
-           |> then_(() =>
-                page->Page.selectOneEval("#input", getElementValueJs)
-              )
+           |> then_(() => page->Page.selectOneEval("#input", getVal))
+           |> then_(value => expect(value) |> toBe("hello world") |> resolve)
          )
-      |> then_(value => value |> expect |> toBe("hello world") |> resolve)
-    )
-  );
+    );
+  });
 
   testPromise("addScriptTag()", () =>
     Js.Promise.(

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -4,6 +4,8 @@ open BsPuppeteer;
 
 open Expect;
 
+module D = Webapi.Dom;
+
 let seconds = v => v * 1000;
 
 [@bs.val] external fetch: string => Js.Promise.t(Response.t) = "";
@@ -14,14 +16,6 @@ let getElementValueJs: Dom.element => string = [%raw
 
 let getLengthOfElementsJs = [%raw
   {| function (elements) { return elements.length; } |}
-];
-
-let getElementOuterHTMLJs: Dom.element => string = [%raw
-  {| function (element) { return element.outerHTML; } |}
-];
-
-let getElementOuterHTMLJsPromise: Dom.element => Js.Promise.t(string) = [%raw
-  {| function (element) { return Promise.resolve(element.outerHTML); } |}
 ];
 
 let fixturesPath =
@@ -265,7 +259,7 @@ describe("Page", () => {
 
   testPromise("$eval() with 0 args", () =>
     Js.Promise.(
-      (page^)->Page.selectOneEval("html", getElementOuterHTMLJs)
+      (page^)->Page.selectOneEval("html", D.Element.outerHTML)
       |> then_(html =>
            html
            |> expect
@@ -277,7 +271,10 @@ describe("Page", () => {
 
   testPromise("$eval() with 0 args returning a promise", () =>
     Js.Promise.(
-      (page^)->Page.selectOneEvalPromise("html", getElementOuterHTMLJsPromise)
+      (page^)
+      ->Page.selectOneEvalPromise("html", el =>
+          el->D.Element.outerHTML->Js.Promise.resolve
+        )
       |> then_(h =>
            h
            |> expect

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -6,6 +6,8 @@ open Expect;
 
 module D = Webapi.Dom;
 
+[@bs.val] external document: D.Document.t = "";
+
 let seconds = v => v * 1000;
 
 [@bs.val] external fetch: string => Js.Promise.t(Response.t) = "";
@@ -605,13 +607,8 @@ describe("Page", () => {
 
   testPromise("evaluateHandle()", () =>
     Js.Promise.(
-      {
-        let eval = () => [%raw {| document |}];
-        (page^)->Page.evaluateHandle(eval);
-      }
-      |> then_(jsHandler =>
-           jsHandler |> expect |> ExpectJs.toBeTruthy |> resolve
-         )
+      (page^)->Page.evaluateHandle(() => document)
+      |> then_(doc => expect(doc) |> ExpectJs.toBeTruthy |> resolve)
     )
   );
 

--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -283,13 +283,15 @@ describe("Page", () => {
            (page^)
            ->Page.selectOneEval1(
                "input",
-               [%raw
-                 {| function (el, prop) { return el.getAttribute(prop); } |}
-               ],
+               (element, prop) =>
+                 switch (D.Element.getAttribute(prop, element)) {
+                 | Some(s) => s
+                 | None => ""
+                 },
                "id",
              )
          )
-      |> then_(id => id |> expect |> toBe("input") |> resolve)
+      |> then_(id => expect(id) |> toBe("input") |> resolve)
     )
   );
 

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -20,7 +20,8 @@
     "error": ""
   },
   "bs-dev-dependencies": [
-    "@glennsl/bs-jest"
+    "@glennsl/bs-jest",
+    "bs-webapi"
   ],
   "refmt": 3,
   "bsc-flags": [

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -8,7 +8,8 @@
     },
     {
       "dir": "examples",
-      "public": []
+      "public": [],
+      "type": "dev"
     },
     {
       "dir": "__tests__",

--- a/examples/search.re
+++ b/examples/search.re
@@ -10,17 +10,35 @@ let search = () =>
        browser
        |> Browser.newPage
        |> then_(page => {
+            let allResultsSelector = ".devsite-suggest-all-results";
             let options =
               Navigation.makeOptions(~timeout=20000., ~waitUntil=`load, ());
-            page->Page.goto("https://google.com", ~options, ())
-            |> then_(_ => page->Page.type_("#lst-ib", "puppeteer", ()))
-            |> then_(() => page->Page.click("input[type='submit']", ()))
-            |> then_(() => page->Page.waitForSelector("h3 a", ()))
+            page
+            ->Page.goto("https://developers.google.com/web/", ~options, ())
+            /* Type into the search box */
+            |> then_(_ =>
+                 page->Page.type_("#searchbox input", "puppeteer", ())
+               )
+            /* Wait for suggestion overlay to show up then click "all results". */
+            |> then_(_ => page->Page.waitForSelector(allResultsSelector, ()))
+            |> then_(() => page->Page.click(allResultsSelector, ()))
+            /* Wait for load of results page. */
+            |> then_(() => {
+                 let resultsSelector = ".gsc-results .gsc-thumbnail-inside a.gs-title";
+                 page->Page.waitForSelector(resultsSelector, ());
+               })
+            /* Get the title of the first result. */
             |> then_(() =>
                  page
-                 ->Page.selectOneEval("h3 a", Webapi.Dom.Element.textContent)
+                 ->Page.selectOneEval(
+                     "a.gs-title",
+                     Webapi.Dom.Element.textContent,
+                   )
                )
-            |> then_(text => Js.log2("Got:", text) |> resolve)
+            /* Log the result title. */
+            |> then_(text =>
+                 Js.log2("First result title: ", text) |> resolve
+               )
             |> then_(_ => Browser.close(browser))
             |> then_(_ => Node.Process.exit(0) |> resolve);
           })

--- a/examples/search.re
+++ b/examples/search.re
@@ -18,12 +18,7 @@ let search = () =>
             |> then_(() => page->Page.waitForSelector("h3 a", ()))
             |> then_(() =>
                  page
-                 ->Page.selectOneEval(
-                     "h3 a",
-                     [%raw
-                       {| function (element) { return element.textContent; } |}
-                     ],
-                   )
+                 ->Page.selectOneEval("h3 a", Webapi.Dom.Element.textContent)
                )
             |> then_(text => Js.log2("Got:", text) |> resolve)
             |> then_(_ => Browser.close(browser))

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.2",
     "bs-platform": "^4.0.2",
+    "bs-webapi": "^0.11.0",
     "husky": "^1.0.0-rc.13",
     "lint-staged": "^7.2"
   }

--- a/src/Evaluator.re
+++ b/src/Evaluator.re
@@ -61,73 +61,64 @@ module Impl = (T: {type t;}) => {
   external evaluateString: (T.t, string) => Js.Promise.t('r) = "evaluate";
 
   [@bs.send]
-  external evaluateHandle:
-    (T.t, unit => JSHandle.t) => Js.Promise.t(JSHandle.t) =
-    "";
+  external evaluateHandle: (T.t, unit => 'r) => Js.Promise.t(JSHandle.t) = "";
 
   [@bs.send]
   external evaluateHandlePromise:
-    (T.t, unit => Js.Promise.t(JSHandle.t)) => Js.Promise.t(JSHandle.t) =
+    (T.t, unit => Js.Promise.t('r)) => Js.Promise.t(JSHandle.t) =
     "";
 
   [@bs.send]
   external evaluateHandle1:
-    (T.t, [@bs.uncurry] ('a => JSHandle.t), 'a) => Js.Promise.t(JSHandle.t) =
+    (T.t, [@bs.uncurry] ('a => 'r), 'a) => Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise1:
-    (T.t, [@bs.uncurry] ('a => Js.Promise.t(JSHandle.t)), 'a) =>
+    (T.t, [@bs.uncurry] ('a => Js.Promise.t('r)), 'a) =>
     Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandle2:
-    (T.t, [@bs.uncurry] (('a, 'b) => JSHandle.t), 'a, 'b) =>
-    Js.Promise.t(JSHandle.t) =
+    (T.t, [@bs.uncurry] (('a, 'b) => 'r), 'a, 'b) => Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise2:
-    (T.t, [@bs.uncurry] (('a, 'b) => Js.Promise.t(JSHandle.t)), 'a, 'b) =>
+    (T.t, [@bs.uncurry] (('a, 'b) => Js.Promise.t('r)), 'a, 'b) =>
     Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandle3:
-    (T.t, [@bs.uncurry] (('a, 'b, 'c) => JSHandle.t), 'a, 'b, 'c) =>
-    Js.Promise.t('r) =
+    (T.t, [@bs.uncurry] (('a, 'b, 'c) => 'r), 'a, 'b, 'c) =>
+    Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise3:
-    (
-      T.t,
-      [@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t(JSHandle.t)),
-      'a,
-      'b,
-      'c
-    ) =>
-    Js.Promise.t('r) =
+    (T.t, [@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t('r)), 'a, 'b, 'c) =>
+    Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandle4:
-    (T.t, [@bs.uncurry] (('a, 'b, 'c, 'd) => JSHandle.t), 'a, 'b, 'c, 'd) =>
-    Js.Promise.t('r) =
+    (T.t, [@bs.uncurry] (('a, 'b, 'c, 'd) => 'r), 'a, 'b, 'c, 'd) =>
+    Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise4:
     (
       T.t,
-      [@bs.uncurry] (('a, 'b, 'c, 'd) => Js.Promise.t(JSHandle.t)),
+      [@bs.uncurry] (('a, 'b, 'c, 'd) => Js.Promise.t('r)),
       'a,
       'b,
       'c,
       'd
     ) =>
-    Js.Promise.t('r) =
+    Js.Promise.t(JSHandle.t) =
     "evaluateHandle";
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,6 +506,10 @@ bs-platform@^4.0.2:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.5.tgz#d4fd9bbdd11765af5b75110a5655065ece05eed6"
 
+bs-webapi@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/bs-webapi/-/bs-webapi-0.11.0.tgz#b4302be75c8f4b3f88a64febd873da065924b26a"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"


### PR DESCRIPTION
The gets rid of the various `%raw` escape hatches that were used in the examples and test suite. This makes the code a better reference for how to evaluate code in the page context while still maintaining type safety. Making all the evaluated code properly typed also turned up a few bugs in `Evaluator` which are now fixed.