### PR TITLE
Make jsHandle and elementHandle container types

### DIFF
--- a/src/ConsoleMessage.re
+++ b/src/ConsoleMessage.re
@@ -3,7 +3,7 @@ type t;
 
 /** The message arguments. */
 [@bs.send]
-external args: t => array(JSHandle.t) = "";
+external args: t => array(JSHandle.t('a)) = "";
 
 /** The text of the console message. */
 [@bs.send]

--- a/src/ElementHandle.re
+++ b/src/ElementHandle.re
@@ -1,19 +1,19 @@
-type t = Types.elementHandle;
+type t('a) = Types.elementHandle('a);
 
 include JSHandle.Impl({
-  type nonrec t = t;
+  type nonrec t('a) = t('a);
 });
 
-external empty: unit => t = "%identity";
+external empty: unit => t('a) = "%identity";
 
 /* Overrides asElement of JSHandle. Guaranteed to return an ElementHandle. */
-[@bs.send] external asElement: t => Types.elementHandle = "";
+[@bs.send] external asElement: t('a) => Types.elementHandle('a) = "";
 
 [@bs.send]
-external boundingBox: t => Js.Promise.t(Js.Null.t(BoundingBox.t)) = "";
+external boundingBox: t('a) => Js.Promise.t(Js.Null.t(BoundingBox.t)) = "";
 
 [@bs.send]
-external boxModel: t => Js.Promise.t(Js.nullable(BoxModel.t)) = "";
+external boxModel: t('a) => Js.Promise.t(Js.nullable(BoxModel.t)) = "";
 
 let boxModel = handle =>
   boxModel(handle)
@@ -21,48 +21,56 @@ let boxModel = handle =>
 
 [@bs.send]
 external click:
-  (t, ~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
+  (t('a), ~options: Click.clickOptions=?, unit) => Js.Promise.t(unit) =
   "";
 
-[@bs.send] external focus: t => Js.Promise.t(unit) = "";
+[@bs.send] external focus: t('a) => Js.Promise.t(unit) = "";
 
-[@bs.send] external hover: t => Js.Promise.t(unit) = "";
+[@bs.send] external hover: t('a) => Js.Promise.t(unit) = "";
 
-[@bs.send] external isIntersectingViewport: t => Js.Promise.t(bool) = "";
+[@bs.send] external isIntersectingViewport: t('a) => Js.Promise.t(bool) = "";
 
 [@bs.send]
 external press:
-  (t, ~key: string, ~options: Keyboard.options=?, unit) => Js.Promise.t(unit) =
+  (t('a), ~key: string, ~options: Keyboard.options=?, unit) =>
+  Js.Promise.t(unit) =
   "";
 
 [@bs.send]
 external screenshot:
-  (t, ~options: Screenshot.options=?, unit) => Js.Promise.t(Node.Buffer.t) =
+  (t('a), ~options: Screenshot.options=?, unit) =>
+  Js.Promise.t(Node.Buffer.t) =
   "";
 
 [@bs.send]
-external selectOne: (t, ~selector: string) => Js.Promise.t(Js.Null.t(t)) =
+external selectOne:
+  (t('a), ~selector: string) => Js.Promise.t(Js.Null.t(t('b))) =
   "$";
 
 [@bs.send]
-external selectAll: (t, ~selector: string) => Js.Promise.t(array(t)) = "$$";
+external selectAll:
+  (t('a), ~selector: string) => Js.Promise.t(array(t('b))) =
+  "$$";
 
 [@bs.send]
-external selectXPath: (t, ~xpath: string) => Js.Promise.t(array(t)) = "$x";
+external selectXPath: (t('a), ~xpath: string) => Js.Promise.t(array(t('b))) =
+  "$x";
 
-[@bs.send] external tap: t => Js.Promise.t(unit) = "";
+[@bs.send] external tap: t('a) => Js.Promise.t(unit) = "";
 
-[@bs.send] external toString: t => string = "";
+[@bs.send] external toString: t('a) => string = "";
 
 [@bs.send]
 external type_:
-  (t, ~text: string, ~options: {. "delay": float}=?, unit) =>
+  (t('a), ~text: string, ~options: {. "delay": float}=?, unit) =>
   Js.Promise.t(unit) =
   "type";
 
 [@bs.send] [@bs.splice]
-external uploadFile: (t, ~filePaths: array(string)) => Js.Promise.t(unit) =
+external uploadFile:
+  (t('a), ~filePaths: array(string)) => Js.Promise.t(unit) =
   "";
 
 [@bs.send]
-external contentFrame: t => Js.Promise.t(Js.Null.t(Types.frameBase)) = "";
+external contentFrame: t('a) => Js.Promise.t(Js.Null.t(Types.frameBase)) =
+  "";

--- a/src/Evaluator.re
+++ b/src/Evaluator.re
@@ -61,51 +61,53 @@ module Impl = (T: {type t;}) => {
   external evaluateString: (T.t, string) => Js.Promise.t('r) = "evaluate";
 
   [@bs.send]
-  external evaluateHandle: (T.t, unit => 'r) => Js.Promise.t(JSHandle.t) = "";
+  external evaluateHandle: (T.t, unit => 'r) => Js.Promise.t(JSHandle.t('r)) =
+    "";
 
   [@bs.send]
   external evaluateHandlePromise:
-    (T.t, unit => Js.Promise.t('r)) => Js.Promise.t(JSHandle.t) =
+    (T.t, unit => Js.Promise.t('r)) => Js.Promise.t(JSHandle.t('r)) =
     "";
 
   [@bs.send]
   external evaluateHandle1:
-    (T.t, [@bs.uncurry] ('a => 'r), 'a) => Js.Promise.t(JSHandle.t) =
+    (T.t, [@bs.uncurry] ('a => 'r), 'a) => Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise1:
     (T.t, [@bs.uncurry] ('a => Js.Promise.t('r)), 'a) =>
-    Js.Promise.t(JSHandle.t) =
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandle2:
-    (T.t, [@bs.uncurry] (('a, 'b) => 'r), 'a, 'b) => Js.Promise.t(JSHandle.t) =
+    (T.t, [@bs.uncurry] (('a, 'b) => 'r), 'a, 'b) =>
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise2:
     (T.t, [@bs.uncurry] (('a, 'b) => Js.Promise.t('r)), 'a, 'b) =>
-    Js.Promise.t(JSHandle.t) =
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandle3:
     (T.t, [@bs.uncurry] (('a, 'b, 'c) => 'r), 'a, 'b, 'c) =>
-    Js.Promise.t(JSHandle.t) =
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandlePromise3:
     (T.t, [@bs.uncurry] (('a, 'b, 'c) => Js.Promise.t('r)), 'a, 'b, 'c) =>
-    Js.Promise.t(JSHandle.t) =
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
   external evaluateHandle4:
     (T.t, [@bs.uncurry] (('a, 'b, 'c, 'd) => 'r), 'a, 'b, 'c, 'd) =>
-    Js.Promise.t(JSHandle.t) =
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   [@bs.send]
@@ -118,7 +120,7 @@ module Impl = (T: {type t;}) => {
       'c,
       'd
     ) =>
-    Js.Promise.t(JSHandle.t) =
+    Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 
   /**
@@ -126,7 +128,8 @@ module Impl = (T: {type t;}) => {
    * Returns a promise containing a JSHandle.
    */
   [@bs.send]
-  external evaluateStringHandle: (T.t, string) => Js.Promise.t(JSHandle.t) =
+  external evaluateStringHandle:
+    (T.t, string) => Js.Promise.t(JSHandle.t('r)) =
     "evaluateHandle";
 };
 

--- a/src/ExecutionContext.re
+++ b/src/ExecutionContext.re
@@ -22,5 +22,5 @@ external name: t => string = "";
  */
 [@bs.send]
 external queryObjects:
-  (t, ~prototypeHandle: JSHandle.t('a)) => JSHandle.t(array(Js.t({..}))) =
+  (t, ~prototypeHandle: JSHandle.t('a)) => JSHandle.t(array('b)) =
   "";

--- a/src/ExecutionContext.re
+++ b/src/ExecutionContext.re
@@ -21,4 +21,6 @@ external name: t => string = "";
  * prototype. Returns a handle to an array of objects with this prototype.
  */
 [@bs.send]
-external queryObjects: (t, ~prototypeHandle: JSHandle.t) => JSHandle.t = "";
+external queryObjects:
+  (t, ~prototypeHandle: JSHandle.t('a)) => JSHandle.t(array(Js.t({..}))) =
+  "";

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -26,17 +26,17 @@ external makeTagOptions:
 
 [@bs.send]
 external selectOne:
-  (t, ~selector: string) => Js.Promise.t(Js.Null.t(ElementHandle.t)) =
+  (t, ~selector: string) => Js.Promise.t(Js.Null.t(ElementHandle.t('a))) =
   "$";
 
 [@bs.send]
 external selectAll:
-  (t, ~selector: string) => Js.Promise.t(array(ElementHandle.t)) =
+  (t, ~selector: string) => Js.Promise.t(array(ElementHandle.t('a))) =
   "$$";
 
 [@bs.send]
 external selectXPath:
-  (t, ~xpath: string) => Js.Promise.t(array(ElementHandle.t)) =
+  (t, ~xpath: string) => Js.Promise.t(array(ElementHandle.t('a))) =
   "$x";
 
 type selectorOptions = {
@@ -62,7 +62,7 @@ external waitForSelector:
 [@bs.send]
 external waitForXPath:
   (t, ~xpath: string, ~options: selectorOptions=?, unit) =>
-  Js.Promise.t(ElementHandle.t) =
+  Js.Promise.t(ElementHandle.t('a)) =
   "";
 
 /**
@@ -280,10 +280,14 @@ external selectAllEvalPromise4:
   "$$eval";
 
 [@bs.send]
-external addScriptTag: (t, tagOptions) => Js.Promise.t(ElementHandle.t) = "";
+external addScriptTag:
+  (t, tagOptions) => Js.Promise.t(ElementHandle.t(Dom.element)) =
+  "";
 
 [@bs.send]
-external addStyleTag: (t, tagOptions) => Js.Promise.t(ElementHandle.t) = "";
+external addStyleTag:
+  (t, tagOptions) => Js.Promise.t(ElementHandle.t(Dom.element)) =
+  "";
 
 [@bs.send]
 external click:

--- a/src/JSHandle.re
+++ b/src/JSHandle.re
@@ -1,23 +1,26 @@
-module Impl = (T: {type t;}) => {
+module Impl = (T: {type t('a);}) => {
   [@bs.send] [@bs.return nullable]
-  external asElement: T.t => option(Types.elementHandle) = "";
+  external asElement: T.t('a) => option(Types.elementHandle('a)) = "";
 
-  [@bs.send] external dispose: T.t => Js.Promise.t(unit) = "";
-
-  [@bs.send] external executionContext: T.t => Types.executionContext = "";
+  [@bs.send] external dispose: T.t('a) => Js.Promise.t(unit) = "";
 
   [@bs.send]
-  external getProperties: T.t => Js.Promise.t(JSMap.t(string, T.t)) = "";
+  external executionContext: T.t('a) => Types.executionContext = "";
 
   [@bs.send]
-  external getProperty: (T.t, ~propertyName: string) => Js.Promise.t(T.t) =
+  external getProperties: T.t('a) => Js.Promise.t(JSMap.t(string, T.t('b))) =
     "";
 
-  [@bs.send] external jsonValue: T.t => Js.Promise.t(Js.t({..})) = "";
+  [@bs.send]
+  external getProperty:
+    (T.t('a), ~propertyName: string) => Js.Promise.t(T.t('b)) =
+    "";
+
+  [@bs.send] external jsonValue: T.t('a) => Js.Promise.t(Js.t({..})) = "";
 };
 
-type t = Types.jsHandle;
+type t('a) = Types.jsHandle('a);
 
 include Impl({
-  type nonrec t = t;
+  type nonrec t('a) = t('a);
 });

--- a/src/Page.re
+++ b/src/Page.re
@@ -250,7 +250,7 @@ external emulateMediaDisable:
 /** Iterates the JS heap finding all the objects with the given prototype. */
 [@bs.send]
 external queryObjects:
-  (t, ~prototypeHandle: JSHandle.t) => Js.Promise.t(JSHandle.t) =
+  (t, ~prototypeHandle: JSHandle.t('a)) => Js.Promise.t(JSHandle.t('b)) =
   "";
 
 /** Reload the current page. */

--- a/src/Types.re
+++ b/src/Types.re
@@ -1,10 +1,10 @@
 type browser;
 
-type elementHandle;
+type elementHandle('a);
 
 type executionContext;
 
-type jsHandle;
+type jsHandle('a);
 
 type request;
 

--- a/src/Types.re
+++ b/src/Types.re
@@ -1,10 +1,10 @@
 type browser;
 
-type elementHandle('a);
+type elementHandle(+'a);
 
 type executionContext;
 
-type jsHandle('a);
+type jsHandle(+'a);
 
 type request;
 


### PR DESCRIPTION
These are wrappers around javascript objects and dom elements,
respectively. By passing a type in their constructors we can track
this and it allows us to infer the return types of many of the eval
functions that return handles.